### PR TITLE
chore(packages): bump uwelcome to v0.3.5 for the portal timeout fix

### DIFF
--- a/elements/bluefin/uwelcome.bst
+++ b/elements/bluefin/uwelcome.bst
@@ -9,11 +9,11 @@ sources:
   filename: uwelcome
   (?):
   - arch == "x86_64":
-      url: github_files:projectbluefin/uwelcome/releases/download/v0.3.4/uwelcome_0.3.4_linux_amd64
-      ref: f9eba23e8b273ba4add3e4ddfe63a17241caacb82548b78cde187bd5c8021ab6
+      url: github_files:projectbluefin/uwelcome/releases/download/v0.3.5/uwelcome_0.3.5_linux_amd64
+      ref: f13733173f3612ffb5de3cf4d49b608198b4db65a24e6421c4c83df4d72d7aab
   - arch == "aarch64":
-      url: github_files:projectbluefin/uwelcome/releases/download/v0.3.4/uwelcome_0.3.4_linux_arm64
-      ref: 93697c18d9dd99fa77401765576495d0c51b7dbf3a892c45b18bb3487f864362
+      url: github_files:projectbluefin/uwelcome/releases/download/v0.3.5/uwelcome_0.3.5_linux_arm64
+      ref: 5b38d182fd7152bac541d0bc8abdf1a04cab848ab0c62d6bba5ef79477342afb
 
 build-depends:
 - core/sandbox-tools.bst


### PR DESCRIPTION
## Summary

uwelcome's accent-color lookup had no timeout, so any context where xdg-desktop-portal cannot start (root shells, TTY logins, a session that hasn't reached graphical-session.target) held the prompt for stacked 120 second D-Bus timeouts. That's the four minute `sudo su -` stall in #1418 and two of the three serialized timeouts freezing GDM logins in #1444.

1. **Bumps `bluefin/uwelcome.bst` from v0.3.4 to v0.3.5** for both arches with freshly computed refs. v0.3.5 carries projectbluefin/uwelcome#4, which bounds the portal read at 2 seconds and falls back to the default palette.

**Verified:** `bst build` succeeds, and the checked-out artifact's actual release binary was tested against a black-holed portal name via `dbus-run-session`: 2.40s to render, where v0.3.4 hangs for over two minutes. With a live portal it renders in 0.08s with the correct accent color. Not yet verified on a booted image; the greeting behavior itself is unchanged.

Related: #1418, #1444, projectbluefin/uwelcome#4

````markdown
```verify
time uwelcome
```
````
