### PR TITLE
fix(ci): sync-next owns files/linux-ogc with the rest of the kernel set

### DIFF
--- a/.github/workflows/sync-next.yml
+++ b/.github/workflows/sync-next.yml
@@ -35,6 +35,7 @@ env:
     patches/freedesktop-sdk.manifest.json
     patches/linux
     patches/linux-ogc
+    files/linux-ogc
     files/filemap.json
     files/fakecap-manifest.tsv
   NEXT_MERGED: >-


### PR DESCRIPTION
## Summary

sync-next has been failing since the #1473 merge, so next stopped receiving testing updates. Tracing it back: my kernel push to next touched `files/linux-ogc/ogc.config.set` and `.unset`, and that directory is in neither NEXT_OWNED nor NEXT_MERGED, so the drop guard refused to run rather than delete the divergence, which is exactly what it is for.

1. **Adds `files/linux-ogc` to NEXT_OWNED.** The whitelist already owns `files/linux`, `patches/linux`, and `patches/linux-ogc`; this directory is the same kernel-stream content and was simply never listed, so the OGC config fragments are now restored from next's tip like the rest of the kernel set.

**Verified:** the failing run's log names exactly those two paths as the refused divergence, and both branches currently carry identical copies of the files, so ownership changes restore behavior without changing any content. The next testing push after this merges should produce a green sync.

Related: #1473
