### PR TITLE
fix(scripts): gen-filemap refuses partial caches, tests pin kernel match

### DIFF
--- a/scripts/gen-filemap.py
+++ b/scripts/gen-filemap.py
@@ -92,6 +92,27 @@ def list_elements(target: str) -> list[str]:
             if strip_ansi(line).strip().endswith(".bst")]
 
 
+def list_uncached_elements(target: str) -> list[str]:
+    """Return element names in *target*'s tree whose artifact is not cached.
+
+    An uncached element silently vanishes from `bst artifact list-contents`
+    output, so a filemap generated against a partial cache drops whole
+    components without any error (the 2026-09 regeneration lost 34 elements
+    this way).  Callers must treat a non-empty result as fatal.
+    """
+    # The Justfile interpolates arguments into shell source, so avoid
+    # whitespace in the format. Split from the right for junction names.
+    out = bst("show", "--format", "%{name}:%{state}", "--deps", "all", target)
+    uncached = []
+    for raw_line in (strip_ansi(l).strip() for l in out.splitlines()):
+        if ":" not in raw_line:
+            continue
+        name, state = raw_line.rsplit(":", 1)
+        if name.endswith(".bst") and state.strip() != "cached":
+            uncached.append(name)
+    return uncached
+
+
 def list_all_contents(elements: list[str]) -> dict[str, list[str]]:
     """Return {element_name: [absolute_paths]} for all *elements* in one call."""
     print(f"Querying artifact contents for {len(elements)} elements...", file=sys.stderr)
@@ -142,6 +163,15 @@ def main() -> int:
 
     elements = list_elements(args.target)
     print(f"Found {len(elements)} elements in dependency tree.", file=sys.stderr)
+
+    uncached = list_uncached_elements(args.target)
+    if uncached:
+        print(f"ERROR: {len(uncached)} elements have no cached artifact; "
+              "a filemap generated now would silently drop them. "
+              "Pull or build the full tree first.", file=sys.stderr)
+        for name in uncached:
+            print(f"  uncached: {name}", file=sys.stderr)
+        return 1
 
     contents = list_all_contents(elements)
 

--- a/scripts/test_gen_filemap.py
+++ b/scripts/test_gen_filemap.py
@@ -7,6 +7,8 @@ main() (filemap assembly, oci/layers skipping, TSV manifest, --dry-run).
 import importlib.util
 import io
 import json
+import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -171,6 +173,7 @@ class MainTests(unittest.TestCase):
             mock.patch.object(sys, "argv", ["gen-filemap.py", *argv]),
             mock.patch.object(sys, "stderr", new=io.StringIO()),
             mock.patch.object(gen_filemap, "list_elements", return_value=list(contents)),
+            mock.patch.object(gen_filemap, "list_uncached_elements", return_value=[]),
             mock.patch.object(gen_filemap, "list_all_contents", return_value=contents),
         ]
         if output_path is not None:
@@ -233,6 +236,7 @@ class MainTests(unittest.TestCase):
                                              "--target", "oci/custom.bst"]), \
              mock.patch.object(sys, "stderr", new=io.StringIO()), \
              mock.patch.object(gen_filemap, "list_elements", return_value=[]) as list_elements, \
+             mock.patch.object(gen_filemap, "list_uncached_elements", return_value=[]), \
              mock.patch.object(gen_filemap, "list_all_contents", return_value={}), \
              redirect_stdout(io.StringIO()):
             gen_filemap.main()
@@ -242,10 +246,97 @@ class MainTests(unittest.TestCase):
         with mock.patch.object(sys, "argv", ["gen-filemap.py", "--dry-run"]), \
              mock.patch.object(sys, "stderr", new=io.StringIO()), \
              mock.patch.object(gen_filemap, "list_elements", return_value=[]) as list_elements, \
+             mock.patch.object(gen_filemap, "list_uncached_elements", return_value=[]), \
              mock.patch.object(gen_filemap, "list_all_contents", return_value={}), \
              redirect_stdout(io.StringIO()):
             gen_filemap.main()
         list_elements.assert_called_once_with(gen_filemap.DEFAULT_TARGET)
+
+
+class UncachedGateTests(unittest.TestCase):
+    """main() must refuse to generate against a partial artifact cache."""
+
+    def test_uncached_elements_abort_generation(self) -> None:
+        contents = {"bluefin/ghostty.bst": ["/usr/bin/ghostty"]}
+        stderr = io.StringIO()
+        with mock.patch.object(sys, "argv", ["gen-filemap.py", "--dry-run"]), \
+             mock.patch.object(sys, "stderr", stderr), \
+             mock.patch.object(gen_filemap, "list_elements", return_value=list(contents)), \
+             mock.patch.object(gen_filemap, "list_uncached_elements",
+                               return_value=["bluefin/zig.bst"]), \
+             mock.patch.object(gen_filemap, "list_all_contents") as contents_mock:
+            rc = gen_filemap.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("uncached: bluefin/zig.bst", stderr.getvalue())
+        contents_mock.assert_not_called()
+
+    def test_state_parsing_flags_non_cached(self) -> None:
+        show_output = "\n".join([
+            "core/linux-fdsdk.bst:cached",
+            "bluefin/zig.bst:buildable",
+            "bluefin/ghostty.bst:cached",
+            "freedesktop-sdk.bst:components/example.bst:fetch needed",
+        ])
+        with mock.patch.object(gen_filemap, "bst", return_value=show_output):
+            self.assertEqual(gen_filemap.list_uncached_elements("x"),
+                             ["bluefin/zig.bst",
+                              "freedesktop-sdk.bst:components/example.bst"])
+
+    @unittest.skipUnless(shutil.which("just"), "just is required")
+    def test_state_format_survives_just_wrapper(self) -> None:
+        # Exercise the real Justfile without launching a container.
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            podman = root / "podman"
+            podman.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+            podman.chmod(0o755)
+            env = {
+                "PATH": tempdir + os.pathsep + os.environ.get("PATH", ""),
+                "HOME": tempdir,
+            }
+            with mock.patch.dict(os.environ, env):
+                # Wrap rather than mock away bst(): capture the arguments
+                # received by the fake podman after shell interpolation.
+                with mock.patch.object(
+                    gen_filemap, "bst", wraps=gen_filemap.bst
+                ) as bst:
+                    gen_filemap.list_uncached_elements("target.bst")
+                    args = gen_filemap.bst(*bst.call_args.args).splitlines()
+            index = args.index("--format")
+            self.assertEqual(args[index + 1], "%{name}:%{state}")
+            self.assertEqual(args[index + 2], "--deps")
+
+
+class KernelFilemapConsistencyTests(unittest.TestCase):
+    """The committed filemap must map the kernels the elements actually pin.
+
+    This is the tripwire for regenerating the filemap against artifacts from
+    an older kernel: the 2026-09 regeneration shipped 7.1.8 module paths into
+    images running 7.2.2.
+    """
+
+    @staticmethod
+    def _pinned_version(element_path: Path, suffix: str = "") -> str:
+        import re
+        ref = re.search(r"^  ref: v([0-9][^-\s]*)-",
+                        element_path.read_text(), re.M)
+        assert ref, f"no pinned ref in {element_path}"
+        return ref.group(1) + suffix
+
+    def test_filemap_matches_pinned_kernel_version(self) -> None:
+        # The filemap is generated from DEFAULT_TARGET (the default variant),
+        # so it only ever contains the linux-fdsdk kernel; the ogc kernel
+        # lives in the gaming variant's tree and has never been mapped.
+        filemap_path = REPOSITORY / "files" / "filemap.json"
+        fdsdk = REPOSITORY / "elements" / "core" / "linux-fdsdk.bst"
+        if not (filemap_path.exists() and fdsdk.exists()):
+            self.skipTest("repo files not present")
+        version = self._pinned_version(fdsdk)
+        text = filemap_path.read_text()
+        # assertIn would embed the 70MB filemap in the failure message.
+        self.assertTrue(f"/usr/lib/modules/{version}" in text,
+                        f"filemap has no module paths for pinned kernel {version}; "
+                        "regenerate it against current artifacts")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The September filemap regeneration silently dropped 34 elements because gen-filemap.py generates from whatever happens to be in the local artifact cache, and it shipped 7.1.8 module paths into a 7.2.2 tree because nothing ties the filemap to the pinned kernels (#1483 cleaned both up). This makes each failure impossible to repeat quietly.

1. **gen-filemap.py now refuses to run against a partial cache.** A new state check lists every element in the dependency tree whose artifact is not cached and exits nonzero naming them, instead of letting them silently vanish from the output.
2. **The test suite gains a kernel tripwire.** A repo-level test asserts the committed filemap contains module paths for the kernel version linux-fdsdk.bst actually pins, so a stale regeneration fails CI instead of merging looking plausible. The ogc kernel is deliberately excluded, it lives in the gaming variant tree and has never been part of the default-target filemap.

**Verified:** the full suite passes (30 tests) against the regenerated filemap, the uncached gate has unit coverage including the abort path, and the tripwire was watched failing against the stale pre-#1483 filemap before passing against the corrected one.

Related: #1460, #1483
