### PR TITLE
ci: revalidate retargeted PRs and document CI-run Justfile recipes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,10 @@ name: Validate
 on:
   pull_request:
     branches: [testing, next, main]
+    # "edited" fires when a PR's base branch changes. Without it, a PR
+    # opened against one branch and retargeted here merges without ever
+    # re-running validation against the new base (see #1386).
+    types: [opened, synchronize, reopened, edited]
   merge_group:
     branches: [testing, next, main]
 

--- a/Justfile
+++ b/Justfile
@@ -74,7 +74,9 @@ bst *ARGS:
         "{{bst2_image}}" \
         bash -c 'bst --colors "$@"' -- ${EFFECTIVE_BST_FLAGS} {{ARGS}}
 
-# Validate BST element graph — mirrors CI validate job.
+# The ONLY recipe CI runs directly (.github/workflows/validate.yml).
+# New python test suites must be registered here to be enforced; anything
+# added to `validate` below runs on developer machines only.
 [group('dev')]
 check-publish-workflow:
     python3 scripts/check_publish_workflow.py
@@ -91,6 +93,9 @@ monitor-pipeline BUILD_RUN_ID="":
     fi
     python3 files/monitor_pipeline.py --build-run-id "{{BUILD_RUN_ID}}"
 
+# Local convenience wrapper. CI does NOT run this recipe; it runs
+# `check-publish-workflow` plus its own bst show steps. Do not register
+# CI-facing checks here.
 [group('dev')]
 validate:
     just check-publish-workflow


### PR DESCRIPTION
## Summary

Two of the bot PRs we closed this week exposed holes in how validation actually runs, this closes both.

1. **Retargeted PRs now re-validate.** #1386 was opened against main, failed triage, and was retargeted to testing, and validate never ran again because a base change does not fire the default `synchronize` event. The branch carried a reference to a nonexistent junction element all the way to review. Adding `edited` to the pull_request types makes a base change trigger a fresh run.

2. **The Justfile now says which recipe CI enforces.** Three separate PRs (#1430, #1438, #1449) registered new test suites into the `validate` recipe, which no workflow executes, so their green checks ran none of the new code. Comments on `check-publish-workflow` and `validate` now state that check-publish-workflow is the only recipe CI runs directly and that CI-facing checks must be registered there.

Verified: actionlint is clean on the workflow change and `just check-publish-workflow` passes locally. The `edited` trigger also fires on title and body edits, which costs a redundant validate run on those, cheap relative to the hole it closes.

Related: #1386 #1430 #1438 #1449
