### PR TITLE
chore(build): remove unreachable architecture configuration

### DIFF
--- a/elements/core/linux-ogc.bst
+++ b/elements/core/linux-ogc.bst
@@ -60,8 +60,6 @@ variables:
       src-arch: x86
   - arch == "aarch64":
       kernel_arch: arm64
-  - arch == "riscv64":
-      kernel_arch: riscv
 
 environment:
   ARCH: '%{kernel_arch}'
@@ -234,7 +232,7 @@ config:
     ln -sr "${targetdir}" "%{install-root}%{indep-libdir}/modules/${release}/build"
 
   (?):
-  - arch in ["aarch64", "riscv64"]:
+  - arch == "aarch64":
       install-commands:
         (>):
         - |

--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -18,10 +18,6 @@ config:
         bootstrap_build_arch: 'x86_64'
     - arch == 'aarch64':
         bootstrap_build_arch: 'aarch64'
-    - arch == "ppc64le":
-        bootstrap_build_arch: "ppc64le"
-    - arch == "riscv64":
-        bootstrap_build_arch: "x86_64"
 
   overrides:
     components/at-spi2-core.bst: gnome-build-meta.bst:sdk/at-spi2-core.bst

--- a/project.conf
+++ b/project.conf
@@ -40,17 +40,13 @@ sandbox:
 
 variables:
   branch: main
+  # One branch per value of the `arch` option above, and every branch defines
+  # the same variable names.
   (?):
     - arch == "x86_64":
         go-arch: "amd64"
-        systemd-arch: "x86-64"
     - arch == "aarch64":
         go-arch: "arm64"
-        systemd-arch: "arm64"
-    - arch == "ppc64le":
-        gcc_arch: "powerpc64le"
-        go-arch: "ppc64le"
-        systemd-arch: "ppc64-le"
 
 # Project name
 


### PR DESCRIPTION
 ## Summary

 Dakota only accepts `x86_64` and `aarch64`, but its BuildStream configuration
still carried branches for unsupported architectures. This removes that unreachable
configuration without changing the supported architecture set.

 1. **Remove unreachable architecture branches.** Drop the `ppc64le` and `riscv64`
cases from the project variables, freedesktop-sdk junction options, and OGC kernel
recipe. Device-tree installation remains enabled for `aarch64`.

 2. **Remove unused variables.** Drop `systemd-arch` and the unreachable `gcc_arch`
assignment. Both supported architecture branches retain their `go-arch` values for
Go builds and OCI metadata.

 **Verified:** `just validate` and whitespace checks pass. BuildStream graph checks
pass for default and NVIDIA targets on both supported architectures, with gaming
enabled and disabled. No image builds or boot tests were run.