### PR TITLE
fix(devmode): adapt developer setup to Dakota

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -73,6 +73,8 @@ depends:
   - freedesktop-sdk.bst:components/skopeo.bst
   - freedesktop-sdk.bst:components/flatpak-builder.bst
 
+  - bluefin/virtualization.bst
+
   - freedesktop-sdk.bst:components/bpf.bst
   - freedesktop-sdk.bst:components/vmlinuxh.bst
   - gnome-build-meta.bst:gnomeos-deps/bpftop.bst

--- a/elements/bluefin/just-overrides.bst
+++ b/elements/bluefin/just-overrides.bst
@@ -8,6 +8,9 @@ build-depends:
 - core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
+depends:
+- freedesktop-sdk.bst:components/python3.bst
+
 variables:
   strip-binaries: ""
 
@@ -23,5 +26,8 @@ config:
   - install -Dm644 default.just "%{install-root}/usr/share/ublue-os/just/default.just"
   - install -Dm644 changelog.just "%{install-root}/usr/share/ublue-os/just/changelog.just"
   - install -Dm644 system.just "%{install-root}/usr/share/ublue-os/just/system.just"
+  - install -Dm755 devmode.py "%{install-root}/usr/libexec/dakota-devmode"
   - install -Dm644 flutter.just "%{install-root}/usr/share/ublue-os/just/flutter.just"
+  - install -Dm644 dakota-dev-flatpaks.Brewfile "%{install-root}/usr/share/ublue-os/homebrew/dakota-dev-flatpaks.Brewfile"
+  - install -Dm644 dakota-fonts.Brewfile "%{install-root}/usr/share/ublue-os/homebrew/dakota-fonts.Brewfile"
   - "%{install-extra}"

--- a/elements/bluefin/virtualization.bst
+++ b/elements/bluefin/virtualization.bst
@@ -1,0 +1,16 @@
+kind: stack
+
+depends:
+- gnome-build-meta.bst:core-deps/libvirt.bst
+- gnome-build-meta.bst:core-deps/qemu.bst
+# sdl2-compat only build-depends on SDL3, but dlopens it when QEMU starts.
+# Keep this runtime dependency until the junction fixes sdl2-compat's closure.
+- freedesktop-sdk.bst:components/sdl3.bst
+
+public:
+  bst:
+    integration-commands:
+    # The junction defaults to root-owned QEMU guests. Its sysusers file creates
+    # a dedicated qemu account; use that without disabling AppArmor or device
+    # isolation. Apply after staging to preserve the setting in both OCI variants.
+    - printf '\n# Dakota system guests run unprivileged.\nuser = "qemu"\ngroup = "qemu"\n' >> /etc/libvirt/qemu.conf

--- a/files/just-overrides/dakota-dev-flatpaks.Brewfile
+++ b/files/just-overrides/dakota-dev-flatpaks.Brewfile
@@ -1,0 +1,10 @@
+# Optional Dakota development apps, all installed from the existing Flathub remote.
+# GNOME Builder is offered separately by ujust install-dev-ides.
+# VMM is installed by ujust setup-virtualization together with libvirt activation.
+# Based on projectbluefin/common's system-dx-flatpaks.Brewfile at 45080bc5a4fee999abc71a6410048350a41ef726.
+# Deliberately excludes Tavern: a Homebrew GUI is not required for development,
+# and its separate Flatpak remote is not part of Dakota's default app selection.
+flatpak "de.leopoldluley.Clapgrep"
+flatpak "io.github.getnf.embellish"
+flatpak "io.podman_desktop.PodmanDesktop"
+flatpak "me.iepure.devtoolbox"

--- a/files/just-overrides/dakota-fonts.Brewfile
+++ b/files/just-overrides/dakota-fonts.Brewfile
@@ -1,0 +1,23 @@
+# Dakota's optional font selection, installed by ujust install-dev-fonts.
+tap "colindean/fonts-nonfree", trusted: true
+
+# Accessibility fonts: use the GitHub-hosted Nerd Font release rather than
+# the original OpenDyslexic cask's broken archive (dakota#1442).
+cask "font-opendyslexic-nerd-font"
+
+# Office fonts
+cask "font-arial"
+cask "font-arial-black"
+cask "font-comic-sans-ms"
+cask "font-impact"
+cask "colindean/fonts-nonfree/font-microsoft-aptos"
+cask "colindean/fonts-nonfree/font-microsoft-fluent"
+cask "colindean/fonts-nonfree/font-microsoft-office"
+
+# Other common fonts
+cask "font-dejavu"
+cask "font-fira-sans"
+cask "font-montserrat"
+cask "font-noto-sans"
+cask "font-roboto"
+cask "font-ubuntu"

--- a/files/just-overrides/devmode.py
+++ b/files/just-overrides/devmode.py
@@ -1,0 +1,525 @@
+#!/usr/bin/python3
+"""Interactive Dakota developer-tool management, using installed state, not a marker."""
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, replace
+
+BREW = "/home/linuxbrew/.linuxbrew/bin/brew"
+VMM_APP_ID = "org.virt_manager.virt-manager"
+DRIVERS = (
+    "qemu",
+    "interface",
+    "network",
+    "nodedev",
+    "nwfilter",
+    "secret",
+    "storage",
+    "proxy",
+)
+SERVICES = tuple(f"virt{driver}d.service" for driver in DRIVERS)
+# Never use virt*.socket globs: those would include remote TCP/TLS listeners.
+SOCKETS = tuple(
+    f"virt{driver}d{suffix}.socket"
+    for driver in DRIVERS
+    for suffix in ("", "-ro", "-admin")
+)
+HELPERS = (
+    "virtlogd.socket",
+    "virtlogd-admin.socket",
+    "virtlockd.socket",
+    "virtlockd-admin.socket",
+)
+BOOT_UNITS = SERVICES + SOCKETS + HELPERS
+FOREIGN_UNITS = (
+    "libvirtd.service",
+    *(f"libvirtd{suffix}.socket" for suffix in ("", "-ro", "-admin", "-tcp", "-tls")),
+    "virtproxyd-tcp.socket",
+    "virtproxyd-tls.socket",
+    "virtvboxd.service",
+    "virtvboxd.socket",
+    "libvirt-guests.service",
+)
+
+
+class SetupError(Exception):
+    """A failed operation that should be reported without a traceback."""
+
+
+def run(
+    *args: str, capture: bool = False, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess:
+    """Run argument vectors only. Never interpolate a selection into a shell command."""
+    try:
+        return subprocess.run(
+            args,
+            text=True,
+            stdout=subprocess.PIPE if capture else None,
+            env=env,
+            check=False,
+        )
+    except OSError as error:
+        raise SetupError(f"Could not run {args[0]}: {error}") from error
+
+
+def checked(*args: str, capture: bool = False) -> str:
+    result = run(*args, capture=capture)
+    if result.returncode:
+        raise SetupError(
+            f"{args[0]} {args[1]} failed with exit code {result.returncode}."
+        )
+    return result.stdout or ""
+
+
+def choose(header: str, options: list[str], *, multiple: bool = False) -> list[str]:
+    flags = ["--no-limit", "--selected="] if multiple else []
+    result = run("gum", "choose", *flags, f"--header={header}", *options, capture=True)
+    if result.returncode in (1, 130, -2):  # Escape or Ctrl-C: no selection, no action.
+        return []
+    if result.returncode:
+        raise SetupError("Could not display the menu.")
+    selected = result.stdout.splitlines()
+    selected = [item for item in selected if item]
+    if any(item not in options for item in selected) or (
+        not multiple and len(selected) > 1
+    ):
+        raise SetupError("Unknown menu selection; nothing was changed.")
+    return list(dict.fromkeys(selected))
+
+
+def confirm(prompt: str) -> bool:
+    result = run("gum", "confirm", "--default=false", prompt)
+    if result.returncode not in (0, 1, 130, -2):
+        raise SetupError("Could not display the confirmation; nothing was changed.")
+    return result.returncode == 0
+
+
+@dataclass(frozen=True)
+class App:
+    name: str
+    package: str
+    manager: str
+    scope: str = ""
+
+    @property
+    def label(self) -> str:
+        source = "Homebrew" if self.manager == "brew" else f"Flatpak, {self.scope}"
+        return f"{self.name} ({source})"
+
+
+# Only these known developer apps are eligible for removal. Fonts, CLI tools,
+# image packages and unrelated applications are deliberately outside this catalog.
+APPS = (
+    App("Visual Studio Code", "ublue-os/tap/visual-studio-code-linux", "brew"),
+    App(
+        "Visual Studio Code Insiders",
+        "ublue-os/tap/visual-studio-code-linux@insiders",
+        "brew",
+    ),
+    App("VSCodium", "ublue-os/tap/vscodium-linux", "brew"),
+    App("Antigravity IDE", "ublue-os/tap/antigravity-ide-linux", "brew"),
+    App("Zed", "ublue-os/tap/zed-linux", "brew"),
+    App("JetBrains Toolbox", "ublue-os/tap/jetbrains-toolbox-linux", "brew"),
+    App("GNOME Builder", "org.gnome.Builder", "flatpak"),
+    App("Clapgrep", "de.leopoldluley.Clapgrep", "flatpak"),
+    App("Embellish", "io.github.getnf.embellish", "flatpak"),
+    App("Podman Desktop", "io.podman_desktop.PodmanDesktop", "flatpak"),
+    App("Dev Toolbox", "me.iepure.devtoolbox", "flatpak"),
+    App("Virtual Machine Manager", VMM_APP_ID, "flatpak"),
+)
+
+
+def installed_apps() -> list[App]:
+    apps = []
+    if os.access(BREW, os.X_OK):
+        casks = set(
+            checked(
+                BREW, "list", "--cask", "--full-name", "-1", capture=True
+            ).splitlines()
+        )
+        apps.extend(
+            app for app in APPS if app.manager == "brew" and app.package in casks
+        )
+    for scope in ("system", "user"):
+        packages = set(
+            checked(
+                "flatpak",
+                "list",
+                f"--{scope}",
+                "--app",
+                "--columns=application",
+                capture=True,
+            ).splitlines()
+        )
+        apps.extend(
+            replace(app, scope=scope)
+            for app in APPS
+            if app.manager == "flatpak" and app.package in packages
+        )
+    return apps
+
+
+def uninstall_apps() -> None:
+    try:
+        inventory = {app.label: app for app in installed_apps()}
+    except SetupError as error:
+        raise SetupError(
+            f"Could not inspect installed apps; nothing will be removed. {error}"
+        ) from error
+    if not inventory:
+        print("No supported developer apps are installed. Nothing to uninstall.")
+        return
+    print("Choose apps with x, then Enter. Nothing is preselected; Escape cancels.")
+    print(
+        "System Flatpaks are shared by every user. Close selected apps before removing them."
+    )
+    selections = choose(
+        "Uninstall selected developer apps", list(inventory), multiple=True
+    )
+    if not selections:
+        return
+    for label in selections:
+        print(f"Remove: {label}")
+    print(
+        "User data, fonts, VM definitions and disks are kept. No zap or data cleanup is performed."
+    )
+    print("Removing JetBrains Toolbox does not uninstall the IDEs it manages.")
+    print("This does not disable libvirt or remove image-owned QEMU/libvirt.")
+    if not confirm("Uninstall only these selected apps?"):
+        return
+    failed = []
+    for label in selections:
+        app = inventory[label]
+        try:
+            if app.manager == "brew":
+                result = run(
+                    BREW,
+                    "uninstall",
+                    "--cask",
+                    app.package,
+                    env={**os.environ, "HOMEBREW_NO_AUTOREMOVE": "1"},
+                )
+            else:
+                result = run(
+                    "flatpak",
+                    "uninstall",
+                    f"--{app.scope}",
+                    "--app",
+                    "--assumeyes",
+                    "--no-related",
+                    app.package,
+                )
+            if result.returncode:
+                failed.append(label)
+        except SetupError as error:
+            print(error, file=sys.stderr)
+            failed.append(label)
+    if failed:
+        raise SetupError(
+            "Could not uninstall: "
+            + ", ".join(failed)
+            + ". Other selections were attempted. Retry with: ujust uninstall-dev-apps"
+        )
+    print("Selected apps uninstalled; user data was kept.")
+
+
+@dataclass(frozen=True)
+class UnitState:
+    name: str
+    load: str
+    boot: str
+    active: str
+
+    @property
+    def enabled(self) -> bool:
+        # Treat nonstandard enablement as configured, not as safe to ignore.
+        return self.boot not in (
+            "",
+            "disabled",
+            "masked",
+            "masked-runtime",
+            "not-found",
+        )
+
+    @property
+    def running(self) -> bool:
+        # Transitional states must not be mistaken for an inactive service.
+        return self.active not in ("inactive", "failed")
+
+
+def unit_states(units: tuple[str, ...]) -> dict[str, UnitState]:
+    output = checked(
+        "systemctl",
+        "show",
+        "--property=Id,LoadState,UnitFileState,ActiveState",
+        *units,
+        capture=True,
+    )
+    states = {}
+    for block in output.strip().split("\n\n"):
+        fields = dict(line.split("=", 1) for line in block.splitlines() if "=" in line)
+        if not all(
+            key in fields for key in ("Id", "LoadState", "UnitFileState", "ActiveState")
+        ):
+            raise SetupError(
+                "Incomplete systemd state; refusing to change virtualization."
+            )
+        states[fields["Id"]] = UnitState(
+            fields["Id"],
+            fields["LoadState"],
+            fields["UnitFileState"],
+            fields["ActiveState"],
+        )
+    if set(states) != set(units):
+        raise SetupError(
+            "Could not inspect every requested unit; refusing to change virtualization."
+        )
+    return states
+
+
+def virtualization_preflight() -> dict[str, UnitState]:
+    states = unit_states(BOOT_UNITS)
+    for state in states.values():
+        if state.load != "loaded":
+            raise SetupError(
+                f"{state.name} is {state.load}. Missing or masked units must be resolved manually; "
+                "nothing was changed."
+            )
+    # Do not silently migrate or reconfigure somebody's existing deployment.
+    for state in unit_states(FOREIGN_UNITS).values():
+        if state.enabled or state.running:
+            raise SetupError(
+                f"{state.name} is active or enabled. Manage this existing libvirt setup manually; "
+                "nothing was changed."
+            )
+    return states
+
+
+def setup_virtualization() -> None:
+    print(
+        "Virtualization setup installs Virtual Machine Manager and activates its system libvirt backend together."
+    )
+    print(
+        "This is a persistent, machine-wide change requiring administrator authorization."
+    )
+    print(
+        "Remote TCP/TLS listeners stay disabled. Existing guest/network/pool autostart settings are respected."
+    )
+    if not confirm("Install VMM and enable local libvirt sockets/services?"):
+        raise SetupError(
+            "Virtualization setup canceled; no changes were made. Retry with: ujust setup-virtualization"
+        )
+    try:
+        virtualization_preflight()
+        checked("sudo", "-v")
+        # Verify the backend before installing the GUI, not just the package download.
+        checked("sudo", "-n", "systemctl", "enable", *BOOT_UNITS)
+        checked("sudo", "-n", "systemctl", "start", *SOCKETS, *HELPERS)
+        states = unit_states(BOOT_UNITS)
+        if any(state.boot != "enabled" for state in states.values()):
+            raise SetupError("Some units were not persistently enabled.")
+        if any(states[unit].active != "active" for unit in SOCKETS + HELPERS):
+            raise SetupError("Some local sockets did not start.")
+        checked(
+            "sudo",
+            "-n",
+            "timeout",
+            "15s",
+            "virsh",
+            "--readonly",
+            "--connect",
+            "qemu:///system",
+            "list",
+            "--name",
+            capture=True,
+        )
+        for scope in ("system", "user"):
+            installed = checked(
+                "flatpak",
+                "list",
+                f"--{scope}",
+                "--app",
+                "--columns=application",
+                capture=True,
+            ).splitlines()
+            if VMM_APP_ID in installed:
+                print(
+                    "Virtual Machine Manager is already installed; leaving it unchanged."
+                )
+                break
+        else:
+            checked(
+                "flatpak", "install", "--system", "--assumeyes", "flathub", VMM_APP_ID
+            )
+    except SetupError as error:
+        raise SetupError(
+            f"Virtualization setup incomplete: {error} Some changes may remain. "
+            "Retry with: ujust setup-virtualization"
+        ) from error
+    print(
+        "Virtual Machine Manager is installed and system libvirt is responding. No reboot is required."
+    )
+
+
+def disable_virtualization(states: dict[str, UnitState]) -> None:
+    if not any(state.enabled for state in states.values()) and not any(
+        states[unit].running for unit in SERVICES + SOCKETS
+    ):
+        print("Local activation is already disabled. No changes were made.")
+        return
+    print(
+        "Close VM managers first. Disabling affects every user and prevents normal VM autostart next boot."
+    )
+    print(
+        "VM definitions, disks, installed apps and autostart preferences are kept; no guest is shut down."
+    )
+    print(
+        "Logging/locking helpers are not stopped, because stopping them can disrupt guests."
+    )
+    if not confirm("Check for active guests, then disable local libvirt activation?"):
+        return
+    checked("sudo", "-v")
+    try:
+        guests = checked(
+            "sudo",
+            "-n",
+            "timeout",
+            "15s",
+            "virsh",
+            "--readonly",
+            "--connect",
+            "qemu:///system",
+            "list",
+            "--name",
+            capture=True,
+        )
+    except SetupError as error:
+        raise SetupError(
+            "Cannot verify active guests; refusing to disable anything. Check libvirt and retry."
+        ) from error
+    if guests.strip():
+        raise SetupError(
+            f"Active guests prevent disabling virtualization:\n{guests.strip()}\n"
+            "Shut them down yourself, then retry ujust manage-virtualization."
+        )
+    # Never stop virtlogd or virtlockd: guests outside this connection, or started
+    # concurrently after the check, may still need them. Only stop management units.
+    try:
+        checked("sudo", "-n", "systemctl", "disable", *BOOT_UNITS)
+        checked("sudo", "-n", "systemctl", "stop", *SOCKETS, *SERVICES)
+        states = unit_states(BOOT_UNITS)
+        if any(state.enabled for state in states.values()) or any(
+            states[unit].running for unit in SERVICES + SOCKETS
+        ):
+            raise SetupError("Some units remain enabled or active.")
+    except SetupError as error:
+        raise SetupError(
+            f"Deactivation may be partially applied: {error} Inspect ujust manage-virtualization."
+        ) from error
+    print("Local management activation disabled. VM data and applications were kept.")
+    print(
+        "Logging/locking helpers may remain active until reboot. Administrators can still start units manually."
+    )
+
+
+def virtualization() -> None:
+    states = unit_states(BOOT_UNITS)
+    print(f"{'Unit':28} {'Load':12} {'Boot':12} Now")
+    for state in states.values():
+        print(f"{state.name:28} {state.load:12} {state.boot:12} {state.active}")
+    print(
+        "Setup installs VMM, starts local sockets now, and enables the drivers at boot for configured autostart objects."
+    )
+    print(
+        "It does not create VMs, networks or storage pools, or change authentication."
+    )
+    selection = choose(
+        "Manage system virtualization",
+        [
+            "Set up or repair virtualization (VMM + libvirt)",
+            "Disable local activation",
+            "Back",
+        ],
+    )
+    if not selection or selection[0] == "Back":
+        return
+    if selection[0] == "Set up or repair virtualization (VMM + libvirt)":
+        setup_virtualization()
+    else:
+        disable_virtualization(virtualization_preflight())
+
+
+def menu() -> None:
+    print(
+        "Dakota developer setup: rerunning this command does not automatically turn anything off."
+    )
+    print(
+        "Apps and virtualization are managed separately; there is no image switch or global enabled marker."
+    )
+    try:
+        print(f"Installed supported developer apps: {len(installed_apps())}")
+    except SetupError as error:
+        print(f"Installed app inventory is unavailable: {error}", file=sys.stderr)
+    try:
+        state = unit_states(("virtqemud.socket",))["virtqemud.socket"]
+        print(
+            f"QEMU management socket: {state.load}, boot={state.boot or 'unavailable'}, now={state.active}."
+        )
+        print("Other units may differ; use Manage virtualization for full state.")
+    except SetupError as error:
+        print(f"System virtualization status is unavailable: {error}", file=sys.stderr)
+    selection = choose(
+        "Manage developer tools",
+        [
+            "Add or retry developer tools",
+            "Manage virtualization",
+            "Uninstall selected developer apps",
+            "Exit",
+        ],
+    )
+    if not selection or selection[0] == "Exit":
+        return
+    if selection[0] == "Add or retry developer tools":
+        checked("ujust", "install-dev-tools")
+    elif selection[0] == "Manage virtualization":
+        virtualization()
+    else:
+        uninstall_apps()
+
+
+def main() -> int:
+    actions = {
+        "menu": menu,
+        "virtualization": virtualization,
+        "setup": setup_virtualization,
+        "uninstall": uninstall_apps,
+    }
+    if len(sys.argv) > 2 or (len(sys.argv) == 2 and sys.argv[1] not in actions):
+        print(
+            "Usage: dakota-devmode [menu|virtualization|setup|uninstall]",
+            file=sys.stderr,
+        )
+        return 2
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        print(
+            "Run ujust devmode in a terminal to manage developer tools.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        actions[sys.argv[1] if len(sys.argv) == 2 else "menu"]()
+    except SetupError as error:
+        print(error, file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print(
+            "\nInterrupted. Any operations already completed are kept; check current state before retrying.",
+            file=sys.stderr,
+        )
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/just-overrides/flutter.just
+++ b/files/just-overrides/flutter.just
@@ -157,14 +157,8 @@ install-flutter:
     fi
     gum style --foreground 82 "✓ Podman socket active"
 
-    # Add user to docker group (ublue-os standard — requires reboot)
-    if ! groups | grep -q '\bdocker\b'; then
-        gum style "Adding user to docker group via ujust dx-group..."
-        ujust dx-group
-        gum style --foreground 214 "⚠ Reboot required for group membership to take effect."
-    else
-        gum style --foreground 82 "✓ Already in docker group"
-    fi
+    # The per-user Podman socket does not need Docker daemon permissions.
+    gum style "Rootless Podman needs no docker group membership or reboot."
     echo ""
 
     # --- Step 7: Antigravity IDE settings (safe merge) ---

--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -13,68 +13,164 @@ bluefin-cli:
 devmode:
     @ujust toggle-devmode
 
-# Toggle the Developer Experience (groups + optional dev flatpaks and fonts)
+# Manage Dakota developer tools (legacy name; never automatically disables them)
 [group('System')]
 toggle-devmode:
+    @/usr/libexec/dakota-devmode menu
+
+# Set up VMM and local libvirt together, or disable activation without removing data
+[group('System')]
+manage-virtualization:
+    @/usr/libexec/dakota-devmode virtualization
+
+# Install Virtual Machine Manager together with its working system libvirt backend
+[group('System')]
+setup-virtualization:
+    @/usr/libexec/dakota-devmode setup
+
+# Explicitly choose installed developer apps to remove, keeping their user data
+[group('System')]
+uninstall-dev-apps:
+    @/usr/libexec/dakota-devmode uninstall
+
+# Add or retry optional tools, including combined VMM/libvirt setup
+[group('System')]
+install-dev-tools:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Dakota bakes the developer stack into every image (podman, distrobox,
-    # skopeo, git, flatpak-builder, the brew toolchain, ...) and publishes no
-    # -dx variant, so unlike Bluefin there is no image rebase here. Developer
-    # mode is group membership plus optional extras, and works the same on a
-    # fresh ISO install with no registry-bound bootc image.
-    if id -nG "$(id -un)" | grep -qw docker ; then
-        gum confirm "Developer mode is on (docker/libvirt/incus/serial groups). Disable it?" || exit 0
-        for g in docker incus-admin libvirt dialout ; do
-            sudo gpasswd -d "$(id -un)" "$g" 2>/dev/null || true
-        done
-        echo "Developer groups removed. Log out and back in for this to take effect."
-        exit 0
+    echo "Dakota ships Podman, Distrobox, Git, Skopeo, and flatpak-builder in every image."
+    echo "This setup offers optional IDEs, development apps, virtualization, and fonts; it does not install Docker."
+    echo "No image switch, group changes, or reboot is needed."
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        echo "Run ujust install-dev-tools in a terminal to choose optional tools." >&2
+        exit 1
     fi
+    # Keep optional installs independent so one failure does not block the other.
+    status=0
+    ujust install-dev-ides || status=$?
+    ujust install-dev-flatpaks || status=$?
+    if gum confirm "Include virtualization (Virtual Machine Manager + system libvirt)?"; then
+        ujust setup-virtualization || status=$?
+    fi
+    ujust install-dev-fonts || status=$?
+    if [ "$status" -ne 0 ]; then
+        echo "Some optional tools could not be installed; use the retry commands above." >&2
+        exit "$status"
+    fi
+    echo "Optional developer setup finished. Run ujust devmode again to add tools or retry."
 
-    gum confirm "Would you like to enable developer mode?" || exit 0
-    ujust dx-group
-    if gum confirm "Do you want to also install the default development flatpaks?" ; then
-        ADD_DEVMODE=1 ujust install-system-flatpaks 0 1
-    fi
-    if gum confirm "Do you want to install extra monospace fonts?" ; then
-        brew bundle install --file=/usr/share/ublue-os/homebrew/fonts.Brewfile
-    fi
-    echo "Log out and back in (or reboot) to pick up the new group memberships."
-
-# Configure docker,incus-admin,libvirt, container manager, serial permissions
+# Compatibility entry point: Dakota no longer applies blanket developer groups
 [group('System')]
 dx-group:
-    #!/usr/bin/pkexec bash
-    append_group() {
-        local group_name="$1"
-        if ! grep -q "^$group_name:" /etc/group; then
-            echo "Appending $group_name to /etc/group"
-            grep "^$group_name:" /usr/lib/group | tee -a /etc/group > /dev/null
+    @echo "Rootless Podman does not require docker group membership."
+    @echo "No group memberships were changed; no reboot is needed for this command."
+
+# Choose optional IDEs from Homebrew and GNOME Builder from Flathub
+[group('System')]
+install-dev-ides:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        echo "Run ujust install-dev-ides in a terminal to choose IDEs." >&2
+        exit 1
+    fi
+    echo "Use the arrow keys to navigate and x to select IDEs, then Enter to install."
+    echo "Nothing is preselected. Press Escape or submit an empty selection to skip."
+    echo "Homebrew options use ublue-os/tap; GNOME Builder uses the existing system Flathub remote."
+    echo "JetBrains Toolbox manages IDE installations; it is not itself an IDE."
+    options=("Visual Studio Code (Homebrew)" "Visual Studio Code Insiders (Homebrew)"
+        "VSCodium (Homebrew)" "Antigravity IDE (Homebrew)")
+    # These tap casks currently download x86_64-only builds.
+    if [[ "$(uname -m)" == x86_64 ]]; then
+        options+=("Zed (Homebrew)" "JetBrains Toolbox (Homebrew)")
+    else
+        echo "Zed and JetBrains Toolbox are omitted: their tap casks currently target x86_64."
+    fi
+    options+=("GNOME Builder (Flatpak)")
+    if selections=$(gum choose --no-limit --selected="" --header="Choose optional IDEs" "${options[@]}"); then
+        [[ -n "$selections" ]] || { echo "IDE installation skipped."; exit 0; }
+    else
+        choice_status=$?
+        case "$choice_status" in
+            1|130) echo "IDE installation skipped."; exit 0 ;;
+            *) echo "IDE selection failed. Retry with: ujust install-dev-ides" >&2; exit "$choice_status" ;;
+        esac
+    fi
+    failed=()
+    while IFS= read -r selection; do
+        case "$selection" in
+            "Visual Studio Code (Homebrew)") cask=visual-studio-code-linux ;;
+            "Visual Studio Code Insiders (Homebrew)") cask=visual-studio-code-linux@insiders ;;
+            "VSCodium (Homebrew)") cask=vscodium-linux ;;
+            "Antigravity IDE (Homebrew)") cask=antigravity-ide-linux ;;
+            "Zed (Homebrew)") cask=zed-linux ;;
+            "JetBrains Toolbox (Homebrew)") cask=jetbrains-toolbox-linux ;;
+            "GNOME Builder (Flatpak)")
+                if flatpak info --system org.gnome.Builder >/dev/null 2>&1 || flatpak info --user org.gnome.Builder >/dev/null 2>&1; then
+                    echo "GNOME Builder is already installed; leaving it unchanged."
+                elif ! flatpak install --system --assumeyes flathub org.gnome.Builder; then
+                    failed+=("$selection")
+                fi
+                continue
+                ;;
+            *) echo "Unknown IDE selection: $selection" >&2; failed+=("$selection"); continue ;;
+        esac
+        if /home/linuxbrew/.linuxbrew/bin/brew list --cask "ublue-os/tap/$cask" >/dev/null 2>&1; then
+            echo "$selection is already installed; leaving it unchanged."
+        elif ! /home/linuxbrew/.linuxbrew/bin/brew install --cask "ublue-os/tap/$cask"; then
+            failed+=("$selection")
         fi
-    }
+    done <<< "$selections"
+    if [[ ${#failed[@]} -ne 0 ]]; then
+        printf 'Could not install: %s\n' "${failed[@]}" >&2
+        echo "Other selections were still attempted. Retry with: ujust install-dev-ides" >&2
+        exit 1
+    fi
+    echo "Selected IDE setup finished. Existing IDEs and user settings were not removed."
 
-    GROUPS_ADD=("docker" "incus-admin" "libvirt" "dialout")
+# Install optional development Flatpaks (IDEs and virtualization are chosen separately)
+[group('System')]
+install-dev-flatpaks:
+    @ADD_DEVMODE=1 ujust install-system-flatpaks 1 1
 
-    for GROUP_ADD in "${GROUPS_ADD[@]}" ; do
-        append_group $GROUP_ADD
-        usermod -aG $GROUP_ADD {{ `id -un` }}
-    done
-
-    echo "Reboot system and log back in to use docker, libvirt, incus, and serial connections."
+# Install optional accessibility, office, and other fonts through Homebrew
+[group('System')]
+install-dev-fonts:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Includes OpenDyslexic Nerd Font (different family names from original OpenDyslexic)."
+    echo "This does not remove original OpenDyslexic fonts or change application font selections."
+    gum confirm "Install optional extra fonts through Homebrew?" || exit 0
+    if brew bundle install --file=/usr/share/ublue-os/homebrew/dakota-fonts.Brewfile; then
+        echo "Optional fonts installed."
+    else
+        status=$?
+        echo "Optional font installation failed; some fonts may have installed." >&2
+        echo "Developer tools are unaffected. Retry with: ujust install-dev-fonts" >&2
+        exit "$status"
+    fi
 
 # Install system flatpaks for rebasers
 [group('System')]
 install-system-flatpaks $confirm="1" $dx_only="0":
     #!/usr/bin/env bash
-    if [[ "$(jq '."image-flavor"' /usr/share/ublue-os/image-info.json)" =~ dx ]] ; then
-        ADD_DEVMODE="${ADD_DEVMODE:-1}"
-    fi
-    if [ "${ADD_DEVMODE:-0}" == "1" ] ; then
+    set -euo pipefail
+    case "$confirm:$dx_only" in
+        0:0|0:1|1:0|1:1) ;;
+        *) echo "confirm and dx_only must be 0 or 1" >&2; exit 2 ;;
+    esac
+    if [ "${ADD_DEVMODE:-0}" == "1" ] || [ "$dx_only" == 1 ] ; then
         if [ "$confirm" != 0 ] ; then
-            gum confirm "Install development flatpaks?" || exit 0
+            gum confirm "Install optional development Flatpaks?" || exit 0
         fi
-        brew bundle --file="${TARGET_FLATPAK_FILE:-/usr/share/ublue-os/homebrew/system-dx-flatpaks.Brewfile}"
+        if brew bundle --file="${TARGET_FLATPAK_FILE:-/usr/share/ublue-os/homebrew/dakota-dev-flatpaks.Brewfile}"; then
+            echo "Optional development Flatpaks installed."
+        else
+            status=$?
+            echo "Optional development Flatpak installation failed; some apps may have installed." >&2
+            echo "Developer tools are unaffected. Retry with: ujust install-dev-flatpaks" >&2
+            exit "$status"
+        fi
     fi
     [ "$dx_only" == 1 ] && exit 0
     if [ "$confirm" != 0 ] ; then


### PR DESCRIPTION
## Summary

`ujust toggle-devmode` fails on Dakota because it assumes missing system groups, includes an unavailable Flatpak, and downloads OpenDyslexic from a failing archive host. This addresses #1442 and makes devmode an explicit setup and management menu rather than an ambiguous on/off toggle.

1. **Separate setup, service management, and removal.** Keep `ujust devmode` and `toggle-devmode` as equivalent entry points. Offer adding tools, managing virtualization, or uninstalling selected developer apps. Read actual package and service state instead of maintaining an enabled marker.

2. **Offer an IDE multi-select.** Install selected native editors through the Homebrew tap, with GNOME Builder available through Flatpak. Nothing is preselected, existing installations are skipped, and x86_64-only casks are omitted on ARM.

3. **Fix optional app and font installation.** Use Dakota-owned Brewfiles to exclude Tavern and replace the broken OpenDyslexic download with OpenDyslexic Nerd Font. Preserve the remaining fonts without modifying common. Installation failures do not block unrelated selections, and retry commands are provided.

4. **Set up Virtual Machine Manager and its backend together.** Offer one virtualization setup action from devmode that activates and checks system libvirt before installing the VMM Flatpak. Reuse GNOME Build Meta’s libvirt and QEMU, include SDL3 to fix QEMU startup, and configure guests to use the dedicated `qemu` account. Explicitly confirmed setup starts local sockets and enables driver services at boot. Failed or canceled setup reports incomplete rather than success. Remote TCP/TLS listeners remain disabled. Separate disable controls refuse when guests are active or their state cannot be verified, and leave logging/locking helpers running to avoid disrupting guests.

5. **Keep removal deliberate and preserve data.** Offer only supported installed developer apps, distinguish user and system Flatpaks, and require confirmation. Removal does not delete user data, fonts, VM definitions, or disks. Image-owned QEMU and libvirt are not removable through devmode.

6. **Use system Python for the management helper.** Keep Just entry points and Gum menus, with structured application records and subprocess handling in Python. Declare the existing system Python runtime dependency explicitly. Remove obsolete Docker group handling from devmode and Flutter setup.

Virtualization remains opt-in, but selecting it sets up VMM and libvirt together rather than leaving backend activation as a separate step. Docker and Dev Containers integration are not included in this change.

Related: #1442


