### PR TITLE
feat(extensions): package and enable quick-settings-audio-panel

### DIFF
--- a/elements/bluefin/gnome-shell-extensions.bst
+++ b/elements/bluefin/gnome-shell-extensions.bst
@@ -17,6 +17,7 @@ depends:
   - bluefin/shell-extensions/gradia-capture.bst
   - bluefin/shell-extensions/gsconnect.bst
   - bluefin/shell-extensions/power-status-color.bst
+  - bluefin/shell-extensions/quick-settings-audio-panel.bst
   - bluefin/shell-extensions/quicksettings-audio-devices-hider.bst
   - bluefin/shell-extensions/quicksettings-audio-devices-renamer.bst
   - bluefin/shell-extensions/syncthing-toggle.bst

--- a/elements/bluefin/shell-extensions/disable-ext-validator.bst
+++ b/elements/bluefin/shell-extensions/disable-ext-validator.bst
@@ -17,7 +17,7 @@ config:
       cat <<EOF > "%{install-root}%{datadir}/glib-2.0/schemas/zz3-bluefin-unsupported-stuff.gschema.override"
       [org.gnome.shell]
       disable-extension-version-validation=true
-      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'fuzzy-application-search@mkhl.codeberg.page', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'Bluetooth-Battery-Meter@maniacx.github.com', 'copyous@boerdereinar.dev', 'power-status-color@local', 'quicksettings-audio-devices-hider@marcinjahn.com', 'quicksettings-audio-devices-renamer@marcinjahn.com', 'syncthing-toggle@rehhouari.github.com', 'tailscale-gnome-qs@tailscale-qs.github.io', 'tilingshell@ferrarodomenico.com']
+      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'fuzzy-application-search@mkhl.codeberg.page', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'Bluetooth-Battery-Meter@maniacx.github.com', 'copyous@boerdereinar.dev', 'power-status-color@local', 'quick-settings-audio-panel@rayzeq.github.io', 'quicksettings-audio-devices-hider@marcinjahn.com', 'quicksettings-audio-devices-renamer@marcinjahn.com', 'syncthing-toggle@rehhouari.github.com', 'tailscale-gnome-qs@tailscale-qs.github.io', 'tilingshell@ferrarodomenico.com']
 
       [org.gnome.shell.extensions.Bluetooth-Battery-Meter]
       level-indicator-color=0

--- a/elements/bluefin/shell-extensions/quick-settings-audio-panel.bst
+++ b/elements/bluefin/shell-extensions/quick-settings-audio-panel.bst
@@ -1,0 +1,33 @@
+kind: manual
+
+sources:
+- kind: zip
+  url: github_files:Rayzeq/quick-settings-audio-panel/releases/download/v103/quick-settings-audio-panel%40rayzeq.github.io.shell-extension.zip
+  ref: 3a6da80e9b391251149bcf87a9cb5dbbccee827887d1aef43be4ee090b04a29f
+
+build-depends:
+- core/sandbox-tools.bst
+- freedesktop-sdk.bst:components/jq.bst
+
+depends:
+- gnome-build-meta.bst:sdk/glib.bst
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    _uuid="$(jq -r .uuid metadata.json)"
+    _dest="%{install-root}%{datadir}/gnome-shell/extensions/${_uuid}"
+    install -d "${_dest}"
+
+    cp -R ./* "${_dest}/"
+
+    glib-compile-schemas --strict "${_dest}/schemas"
+
+    install -Dm644 schemas/org.gnome.shell.extensions.quick-settings-audio-panel.gschema.xml \
+      "%{install-root}%{datadir}/glib-2.0/schemas/org.gnome.shell.extensions.quick-settings-audio-panel.gschema.xml"
+  - |
+    %{install-extra}


### PR DESCRIPTION
## Summary

Stacks on top of #1510 (`feat/add-gnome-extensions`).

Packages and enables **Quick Settings Audio Panel** (`quick-settings-audio-panel@rayzeq.github.io`):
- Pinned to upstream GitHub release `v103` (GNOME 50 compatible).
- Adds volume sliders, media controls, and per-app audio controls in Quick Settings.
- Enabled by default in `elements/bluefin/shell-extensions/disable-ext-validator.bst`.

## Verification

- `just check-publish-workflow`: passed (20/20 check_publish_workflow, 31/31 test_gen_filemap, 44/44 test_image_variants)
- `just test-render-card`: passed (31/31)