### PR TITLE
feat(extensions): swap bluetooth-battery-meter for budslink-companion and preinstall flatpak

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -122,4 +122,7 @@ config:
     # Dakota uses its own ublue-motd (from motd.bst) with a double-display guard.
     # Remove common's umotd.sh hook to prevent dual MOTD on every login.
     rm -f "%{install-root}%{sysconfdir}/profile.d/umotd.sh"
+
+    # Add BudsLink to default system flatpaks
+    echo 'flatpak "io.github.maniacx.BudsLink"' >> "%{install-root}%{datadir}/ublue-os/homebrew/system-flatpaks.Brewfile"
   - "%{install-extra}"

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -32,6 +32,7 @@ depends:
   - bluefin/swapfile.bst
   - bluefin/firstboot-date.bst
   - bluefin/firstboot-services.bst
+  - bluefin/flatpak-apps.bst
   - bluefin/wallpaper-month.bst
   - bluefin/bootc-install-config.bst
   - bluefin/composefs-loop-udisks-ignore.bst

--- a/elements/bluefin/flatpak-apps.bst
+++ b/elements/bluefin/flatpak-apps.bst
@@ -1,0 +1,28 @@
+# Bluefin Flatpak preinstall declarations.
+#
+# Declares Flathub preinstalls for the default Bluefin desktop image.
+# bluefin/firstboot-services.bst owns the first-boot preinstall service; this element
+# drops *.preinstall files into /usr/share/flatpak/preinstall.d/ for that service to consume.
+kind: manual
+
+sources:
+- kind: local
+  path: files/oci/bluefin-flatpak
+  directory: bluefin-flatpak
+
+build-depends:
+- freedesktop-sdk.bst:bootstrap/bash.bst
+- freedesktop-sdk.bst:bootstrap/coreutils.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ''
+
+config:
+  install-commands:
+  - |
+    for preinstall in bluefin-flatpak/preinstall.d/*.preinstall; do
+      install -Dm644 "$preinstall" "%{install-root}/usr/share/flatpak/preinstall.d/$(basename "$preinstall")"
+    done

--- a/elements/bluefin/gnome-shell-extensions.bst
+++ b/elements/bluefin/gnome-shell-extensions.bst
@@ -7,8 +7,8 @@ depends:
   # FIXME: cleanup custom make destdirs set when not needed
   - bluefin/shell-extensions/app-indicators.bst
   - bluefin/shell-extensions/bazaar-companion.bst
-  - bluefin/shell-extensions/bluetooth-battery-meter.bst
   - bluefin/shell-extensions/blur-my-shell.bst
+  - bluefin/shell-extensions/budslink-companion.bst
   - bluefin/shell-extensions/caffeine.bst
   - bluefin/shell-extensions/copyous.bst
   - bluefin/shell-extensions/custom-command-menu.bst

--- a/elements/bluefin/shell-extensions/budslink-companion.bst
+++ b/elements/bluefin/shell-extensions/budslink-companion.bst
@@ -2,9 +2,9 @@ kind: manual
 
 sources:
 - kind: git_repo
-  url: github:maniacx/Bluetooth-Battery-Meter.git
-  track: GNOME46
-  ref: 1862ef79b69756aee2297bd15a6ae6656b7c11ab
+  url: github:maniacx/BudsLink-Companion.git
+  track: Gnome-Extension
+  ref: c11b6cf5626ee5417efc0af91148736e0697c354
 
 build-depends:
 - core/sandbox-tools.bst
@@ -25,7 +25,7 @@ config:
     _dest="%{install-root}%{datadir}/gnome-shell/extensions/${_uuid}"
     install -d "${_dest}"
 
-    cp -R extension.js prefs.js metadata.json stylesheet.css icons lib preferences ui script schemas "${_dest}/"
+    cp -R extension.js prefs.js metadata.json stylesheet.css icons lib preferences ui schemas "${_dest}/"
     install -Dm644 LICENSE "${_dest}/LICENSE"
     install -Dm644 README.md "${_dest}/README.md"
 
@@ -38,7 +38,7 @@ config:
 
     glib-compile-schemas --strict "${_dest}/schemas"
 
-    install -Dm644 schemas/org.gnome.shell.extensions.Bluetooth-Battery-Meter.gschema.xml \
-      "%{install-root}%{datadir}/glib-2.0/schemas/org.gnome.shell.extensions.Bluetooth-Battery-Meter.gschema.xml"
+    install -Dm644 schemas/org.gnome.shell.extensions.BudsLink-Companion.gschema.xml \
+      "%{install-root}%{datadir}/glib-2.0/schemas/org.gnome.shell.extensions.BudsLink-Companion.gschema.xml"
   - |
     %{install-extra}

--- a/elements/bluefin/shell-extensions/disable-ext-validator.bst
+++ b/elements/bluefin/shell-extensions/disable-ext-validator.bst
@@ -17,9 +17,9 @@ config:
       cat <<EOF > "%{install-root}%{datadir}/glib-2.0/schemas/zz3-bluefin-unsupported-stuff.gschema.override"
       [org.gnome.shell]
       disable-extension-version-validation=true
-      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'fuzzy-application-search@mkhl.codeberg.page', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'Bluetooth-Battery-Meter@maniacx.github.com', 'copyous@boerdereinar.dev', 'power-status-color@local', 'quick-settings-audio-panel@rayzeq.github.io', 'quicksettings-audio-devices-hider@marcinjahn.com', 'quicksettings-audio-devices-renamer@marcinjahn.com', 'syncthing-toggle@rehhouari.github.com', 'tailscale-gnome-qs@tailscale-qs.github.io', 'tilingshell@ferrarodomenico.com']
+      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'fuzzy-application-search@mkhl.codeberg.page', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'BudsLink-Companion@maniacx.github.com', 'copyous@boerdereinar.dev', 'power-status-color@local', 'quick-settings-audio-panel@rayzeq.github.io', 'quicksettings-audio-devices-hider@marcinjahn.com', 'quicksettings-audio-devices-renamer@marcinjahn.com', 'syncthing-toggle@rehhouari.github.com', 'tailscale-gnome-qs@tailscale-qs.github.io', 'tilingshell@ferrarodomenico.com']
 
-      [org.gnome.shell.extensions.Bluetooth-Battery-Meter]
+      [org.gnome.shell.extensions.BudsLink-Companion]
       level-indicator-color=0
 
       [org.gnome.shell.extensions.syncthing-toggle]

--- a/files/oci/bluefin-flatpak/preinstall.d/io.github.maniacx.BudsLink.preinstall
+++ b/files/oci/bluefin-flatpak/preinstall.d/io.github.maniacx.BudsLink.preinstall
@@ -1,0 +1,3 @@
+[Flatpak Preinstall io.github.maniacx.BudsLink]
+Branch=stable
+IsRuntime=false


### PR DESCRIPTION
## Summary

Stacks on top of #1511 (`feat/quick-settings-audio-panel`).

- **Swap Earbuds Extension**: Removes `bluetooth-battery-meter.bst` (`Bluetooth-Battery-Meter@maniacx.github.com`) and adds `budslink-companion.bst` (`BudsLink-Companion@maniacx.github.com`), tracking branch `Gnome-Extension` from `maniacx/BudsLink-Companion` (commit `c11b6cf5626ee5417efc0af91148736e0697c354`).
- **Default Flatpak Preinstall**: Installs `io.github.maniacx.BudsLink` via `/usr/share/flatpak/preinstall.d/io.github.maniacx.BudsLink.preinstall` using new element `elements/bluefin/flatpak-apps.bst`.
- **System Flatpaks Brewfile**: Appends `io.github.maniacx.BudsLink` to `/usr/share/ublue-os/homebrew/system-flatpaks.Brewfile`.

## Verification

- `just check-publish-workflow`: passed (20/20 check_publish_workflow, 31/31 test_gen_filemap, 44/44 test_image_variants)
- `just test-render-card`: passed (31/31)
- `just patch-drift-check`: passed