### PR TITLE
feat(ghostty): configure dual-theme to track GNOME Dark/Light style

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -73,6 +73,14 @@ The common source import also does not supply `fastfetch-user-count` or
 `bazaar-install-count`; those weekly-statistics inputs remain a separate parity
 gap, not a reason to fork the config or invent counts.
 
+## Ghostty theme ownership
+
+`bluefin/common.bst` imports Ghostty's GNOME profile from `projectbluefin/common`.
+Because Dakota uses Ghostty as its primary terminal emulator,
+`patches/common/0002-ghostty-dual-theme.patch` configures `theme = light:Catppuccin Latte,dark:Catppuccin Mocha`
+so that Ghostty follows the GNOME Dark/Light style toggle button out of the box.
+Drop this patch once common carries dual-theme by default.
+
 ## What NOT to do
 
 | Don't | Why |

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -9,6 +9,10 @@ sources:
 # Drop this patch once common provides a shared install-date helper.
 - kind: patch
   path: patches/common/0001-fastfetch-install-date.patch
+# Dakota uses Ghostty as primary terminal: enable dual-theme to track GNOME Dark/Light style.
+# Drop this patch once common ships dual-theme by default.
+- kind: patch
+  path: patches/common/0002-ghostty-dual-theme.patch
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding

--- a/patches/common/0002-ghostty-dual-theme.patch
+++ b/patches/common/0002-ghostty-dual-theme.patch
@@ -1,0 +1,17 @@
+Upstream-Status: Pending
+
+Configure Ghostty dual-theme to track GNOME's Dark/Light style toggle button.
+Dakota uses Ghostty as its primary terminal emulator.
+Exit: Drop once common ships dual-theme by default.
+
+--- a/system_files/shared/etc/skel/.config/ghostty/config.ghostty
++++ b/system_files/shared/etc/skel/.config/ghostty/config.ghostty
+@@ -1,7 +1,7 @@
+ # Bluefin GNOME profile for Ghostty
+ # To override the theme, add `theme = <name>` to your config.
+ # Run `ghostty +list-themes` to see all available themes.
+-theme = Catppuccin Mocha
++theme = light:Catppuccin Latte,dark:Catppuccin Mocha
+ 
+ # Run as a single GTK instance, consistent with GNOME app conventions
+ gtk-single-instance = true


### PR DESCRIPTION
## Summary

Configures Ghostty's default profile to use native dual theming (`theme = light:Catppuccin Latte,dark:Catppuccin Mocha`) via `patches/common/0002-ghostty-dual-theme.patch`.

Note: The GNOME Shell adaptive light style extension has been extracted into its own extension in `projectbluefin/bluefin-bling` (#1).

## Verification

- `just check-publish-workflow`: passed (20/20 check_publish_workflow, 31/31 test_gen_filemap, 44/44 test_image_variants)
- `just test-render-card`: passed (31/31)
- `just patch-drift-check`: passed