### PR TITLE
feat(launcher): package vicinae and bind launcher toggle to Super+Space

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -46,6 +46,7 @@ depends:
   - bluefin/fprintd-system-auth.bst
   - bluefin/efibootmgr.bst
   - bluefin/xdg-terminal-exec.bst
+  - bluefin/vicinae.bst
   - bluefin/nautilus-python.bst
   - bluefin/gnome-ponytail-daemon.bst
   # Restores the VTE typelibs the app-drop strips out (dakota#1022)

--- a/elements/bluefin/vicinae.bst
+++ b/elements/bluefin/vicinae.bst
@@ -1,0 +1,42 @@
+kind: manual
+
+sources:
+- kind: tar
+  url: github_files:vicinaehq/vicinae/releases/download/v0.28.1/vicinae-linux-x86_64-v0.28.1.tar.gz
+  ref: 4bc9ad954742a48a771e0b5d2dbcff85091c6215aa655405ab576566047b5488
+
+build-depends:
+- core/sandbox-tools.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 bin/vicinae "%{install-root}%{bindir}/vicinae"
+
+    for f in libexec/vicinae/*; do
+      install -Dm755 "$f" "%{install-root}%{prefix}/libexec/vicinae/$(basename "$f")"
+    done
+
+    install -Dm644 share/applications/vicinae.desktop "%{install-root}%{datadir}/applications/vicinae.desktop"
+    install -Dm644 share/applications/vicinae-url-handler.desktop "%{install-root}%{datadir}/applications/vicinae-url-handler.desktop"
+
+    install -Dm644 share/icons/hicolor/512x512/apps/vicinae.png "%{install-root}%{datadir}/icons/hicolor/512x512/apps/vicinae.png"
+
+    mkdir -p "%{install-root}%{datadir}/vicinae"
+    cp -r share/vicinae/* "%{install-root}%{datadir}/vicinae/"
+
+    install -Dm644 lib/systemd/user/vicinae.service "%{install-root}%{indep-libdir}/systemd/user/vicinae.service"
+
+    mkdir -p "%{install-root}%{indep-libdir}/systemd/user/graphical-session.target.wants"
+    ln -sfn ../vicinae.service "%{install-root}%{indep-libdir}/systemd/user/graphical-session.target.wants/vicinae.service"
+
+    install -Dm644 lib/modules-load.d/vicinae.conf "%{install-root}%{indep-libdir}/modules-load.d/vicinae.conf"
+  - |
+    %{install-extra}

--- a/files/dconf/06-dakota-keybindings
+++ b/files/dconf/06-dakota-keybindings
@@ -3,6 +3,12 @@
 # which is not installed in dakota. Override to use xdg-terminal-exec (Ghostty).
 # See: https://github.com/projectbluefin/common/pull/265
 
+[org/gnome/desktop/wm/keybindings]
+switch-input-source=['<Shift><Super>space']
+
+[org/gnome/settings-daemon/plugins/media-keys]
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/']
+
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
 binding='<Control><Alt>t'
 command='/usr/bin/xdg-terminal-exec'
@@ -12,3 +18,8 @@ name='Terminal'
 binding='<Control><Alt>Return'
 command='/usr/bin/xdg-terminal-exec'
 name='Terminal Alt'
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4]
+binding='<Super>space'
+command='vicinae toggle'
+name='Vicinae Launcher'


### PR DESCRIPTION
## Summary

Stacks on top of #1512 (`feat/budslink-companion`).

- **Package Vicinae**: Packages Vicinae launcher v0.28.1 (`elements/bluefin/vicinae.bst`) from GitHub release tarball with desktop entries, themes, helper binaries, and `vicinae.service` user unit enabled in `graphical-session.target`.
- **Keybinding Override**: In `files/dconf/06-dakota-keybindings`, rebinds GNOME's input source toggle to `<Shift><Super>space` and binds `<Super>space` to `vicinae toggle`.

## Verification

- `just check-publish-workflow`: passed (20/20 check_publish_workflow, 31/31 test_gen_filemap, 44/44 test_image_variants)
- `just test-render-card`: passed (31/31)
- `just patch-drift-check`: passed