### PR TITLE
fix(extensions): preserve metadata when extracting ZIPs

### DIFF
--- a/.agents/skills/dakota-extensions/SKILL.md
+++ b/.agents/skills/dakota-extensions/SKILL.md
@@ -2,6 +2,8 @@
 name: dakota-extensions
 description: Package, update, and configure GNOME Shell extensions, Quick Settings panels, and schemas in Dakota. Use when editing elements/bluefin/shell-extensions/ or dconf extension defaults.
 metadata:
+  verified-sources:
+    - https://buildstream.gitlab.io/buildstream-plugins-community/sources/zip.html
   context7-sources:
     - /git_gitlab_gnome_org/gnome_gnome-shell
 ---
@@ -31,6 +33,11 @@ Dakota packages curated GNOME Shell extensions built from source or upstream rep
 2. **Create Element**:
    - Add `elements/bluefin/shell-extensions/<name>.bst` using `kind: manual`.
    - Source from pinned git commit or release tag.
+   - For release ZIPs with `metadata.json` at the archive root, set `base-dir: ""`
+     in the `kind: zip` source. The plugin default (`'*'`) extracts a child
+     directory instead, dropping root-level files. Inspect the pinned archive's
+     layout before choosing an extraction root; source-tree archives may have a
+     wrapper directory.
    - Extract UUID via `jq` and install files into:
      ```bash
      _uuid="$(jq -r .uuid metadata.json)"
@@ -48,6 +55,9 @@ Dakota packages curated GNOME Shell extensions built from source or upstream rep
 5. **Configure Default Enablement**:
    - If enabled by default, add the UUID to `enabled-extensions` in the appropriate dconf override file under `files/dconf/`.
 6. **Validate & Build**:
+   Graph validation (`bst show`) does not stage sources or execute installation
+   commands. Build the changed extension and inspect its installed metadata and
+   schemas; a green graph check alone cannot verify archive extraction.
    ```bash
    just validate
    just bst build bluefin/shell-extensions/<name>.bst

--- a/elements/bluefin/shell-extensions/copyous.bst
+++ b/elements/bluefin/shell-extensions/copyous.bst
@@ -2,6 +2,7 @@ kind: manual
 
 sources:
 - kind: zip
+  base-dir: ""
   url: github_files:boerdereinar/copyous/releases/download/v2.0.1/copyous%40boerdereinar.dev.zip
   ref: 7c2bfdecd66b78dc1f2491ae74e16216fca7190307411de21966da9fd47d4141
 

--- a/elements/bluefin/shell-extensions/quick-settings-audio-panel.bst
+++ b/elements/bluefin/shell-extensions/quick-settings-audio-panel.bst
@@ -2,6 +2,7 @@ kind: manual
 
 sources:
 - kind: zip
+  base-dir: ""
   url: github_files:Rayzeq/quick-settings-audio-panel/releases/download/v103/quick-settings-audio-panel%40rayzeq.github.io.shell-extension.zip
   ref: 3a6da80e9b391251149bcf87a9cb5dbbccee827887d1aef43be4ee090b04a29f
 

--- a/elements/bluefin/shell-extensions/quicksettings-audio-devices-hider.bst
+++ b/elements/bluefin/shell-extensions/quicksettings-audio-devices-hider.bst
@@ -2,6 +2,7 @@ kind: manual
 
 sources:
 - kind: zip
+  base-dir: ""
   url: gnome_extensions:quicksettings-audio-devices-hider@marcinjahn.com.shell-extension.zip?version_tag=69924
   ref: 217082e049572ae54bc90bc09240f896e25f4a2609e0c0aa4b7133bed46d935d
 

--- a/elements/bluefin/shell-extensions/quicksettings-audio-devices-renamer.bst
+++ b/elements/bluefin/shell-extensions/quicksettings-audio-devices-renamer.bst
@@ -2,6 +2,7 @@ kind: manual
 
 sources:
 - kind: zip
+  base-dir: ""
   url: gnome_extensions:quicksettings-audio-devices-renamer@marcinjahn.com.shell-extension.zip?version_tag=69925
   ref: a4f33897983376a23c5de69d6a008d1451afcc05cd7ce3b56630bd739c095a2e
 

--- a/elements/bluefin/shell-extensions/tilingshell.bst
+++ b/elements/bluefin/shell-extensions/tilingshell.bst
@@ -2,6 +2,7 @@ kind: manual
 
 sources:
 - kind: zip
+  base-dir: ""
   url: github_files:domferr/tilingshell/releases/download/17.3/tilingshell%40ferrarodomenico.com.zip
   ref: 63ab8230b62c1a888d5af40e47aef0676e5e99ac367e35f51a797fe3b9a79370
 


### PR DESCRIPTION
## Summary

The overnight and scheduled testing builds failed while packaging five GNOME extensions because their install commands could not find `metadata.json`.

1. **Extract the archive root.** Set `base-dir: ""` for Copyous, Quick Settings Audio Panel, Audio Devices Hider, Audio Devices Renamer, and Tiling Shell. Their release ZIPs contain metadata at the root, but BuildStream's default selects a subdirectory instead. Versions and checksums remain unchanged.

2. **Clarify the packaging guidance.** Document the extraction setting and explain why graph validation alone does not catch installation failures.

Verified: `just validate` passed. All five affected elements were built locally with their installation commands and schema compilation completing successfully. Their artifacts contain the expected metadata, UUID directories, JavaScript, and compiled schemas. The complete image has not been built locally; desktop behavior will be tested on the testing image.

Related: #1510, #1511
