### PR TITLE
fix(skills): make factory frontmatter parseable

### DIFF
--- a/.agents/skills/dakota-factory/SKILL.md
+++ b/.agents/skills/dakota-factory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dakota-factory
-description: Reinforce the Project Bluefin factory model: two-output rule, docs-as-the-model hygiene, Context7 freshness protocol, and skill auditing. Use when finishing sessions, auditing skills, or writing back learned patterns.
+description: "Reinforce the Project Bluefin factory model: two-output rule, docs-as-the-model hygiene, Context7 freshness protocol, and skill auditing. Use when finishing sessions, auditing skills, or writing back learned patterns."
 metadata:
   context7-sources:
     - /addyosmani/agent-skills


### PR DESCRIPTION
## Summary

Pi cannot load the `dakota-factory` skill added in #1516 because its YAML frontmatter contains an unquoted colon followed by a space in the description. This produces the “Nested mappings are not allowed in compact mappings” warning.

1. **Quote the description.** This makes YAML treat the full description as a string without changing its wording or the skill instructions.

Verified: The original frontmatter fails with Pi's installed YAML parser, and the corrected frontmatter parses successfully. The description value and skill body are unchanged. `git diff --check` passes. Image, boot, and publish verification are not applicable to this Markdown-only fix.

Related: #1516
