### PR TITLE
fix(next): avoid adjacent dependency sync conflict

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -38,6 +38,20 @@ Publish records the pushed digest and passes that receipt between jobs. Signing,
 attestation, stream-tag promotion, and verification operate on the resolved SHA
 or digest rather than rediscovering mutable tag state.
 
+## Next synchronization
+
+`sync-next.yml` synthesizes `next` from `testing`, restores `NEXT_OWNED` paths,
+and three-way merges `NEXT_MERGED` files. Divergence outside those lists or a
+merge conflict stops the sync before its lease-protected push.
+
+Keep unrelated dependency additions away from next-only replacement blocks in
+`NEXT_MERGED` files (for example, the BPF dependencies in `bluefin/deps.bst`).
+Even an insertion adjacent to a replacement can conflict. Moving that insertion
+on `testing` without changing the dependency set can unblock the merge without
+changing next's SDK overlay. Check all merged files against the current branch
+tips; do not resolve these conflicts by blindly choosing either entire file or
+by expanding `NEXT_OWNED`, which would prevent testing updates flowing through.
+
 ## Stable release
 
 `execute-release.yml` is scheduled after the daily build window. It resolves the

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -65,6 +65,8 @@ depends:
   # transitively via gnome-control-center otherwise (projectbluefin/dakota#1163)
   - gnome-build-meta.bst:core-deps/libgtop.bst
 
+  - bluefin/virtualization.bst
+
   - freedesktop-sdk.bst:components/buildstream2.bst
   - freedesktop-sdk.bst:components/containers-common.bst
   - freedesktop-sdk.bst:components/debuginfod.bst
@@ -74,8 +76,6 @@ depends:
   - freedesktop-sdk.bst:components/podman.bst
   - freedesktop-sdk.bst:components/skopeo.bst
   - freedesktop-sdk.bst:components/flatpak-builder.bst
-
-  - bluefin/virtualization.bst
 
   - freedesktop-sdk.bst:components/bpf.bst
   - freedesktop-sdk.bst:components/vmlinuxh.bst


### PR DESCRIPTION
## Summary

`Sync next` is failing because the virtualization dependency added on `testing` sits directly beside next’s BPF replacement in `elements/bluefin/deps.bst`. Git treats these adjacent edits as a conflict, blocking testing updates from reaching next.

1. **Unblock the sync without changing dependencies.** Move the virtualization entry away from the BPF block so testing’s additions merge cleanly while preserving next’s SDK-specific dependencies.
2. **Document the conflict pattern.** Add guidance to `docs/ci.md` for keeping unrelated additions separate from next-only replacements without weakening the sync guards.

Verified: `just validate` passes on the fix branch. Local replay reproduces the original failure, then passes with this change. All four overlay files merge correctly, repeat sync produces an identical tree, and the drop guard still rejects unexpected divergence. All four synthesized-next image graphs resolve. Full image build and publish verification remain outstanding.

Next’s full validation still hits a separate kernel-7.3 filemap consistency failure, also reproduced on unchanged upstream `next`.

Related: https://github.com/projectbluefin/dakota/actions/runs/34183659314
