### PR TITLE
fix(ci): require diagnostic report intake

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@393d04285f4d0a0042b8f5fb0034c876423b7957 # require diagnostic Gists
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@03f32c481d0c435606a5f0fc2745e7116d70bbaa # require diagnostic Gists
     with:
       brand_name: "Dakota"
     secrets: inherit

--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@7f2875210d89a170858f962cd6a089d4a813f214 # require diagnostic Gists
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@ebdd828be9a9c2f0c1fcac62574b6824463f8cba # require diagnostic Gists
     with:
       brand_name: "Dakota"
     secrets: inherit

--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@aa3185566171de43106976cd5a0ac72ee3106868 # clanker-queue-rollout
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@7f2875210d89a170858f962cd6a089d4a813f214 # require diagnostic Gists
     with:
       brand_name: "Dakota"
     secrets: inherit

--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@ebdd828be9a9c2f0c1fcac62574b6824463f8cba # require diagnostic Gists
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@e4fc04c6e35845a3c2b75d498e8640c51c3b5057 # require diagnostic Gists
     with:
       brand_name: "Dakota"
     secrets: inherit

--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@e4fc04c6e35845a3c2b75d498e8640c51c3b5057 # require diagnostic Gists
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@393d04285f4d0a0042b8f5fb0034c876423b7957 # require diagnostic Gists
     with:
       brand_name: "Dakota"
     secrets: inherit

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -117,6 +117,10 @@ Metadata rows are pulled live from GitHub at every transition:
 
 `ujust confirm` adds another hardware instance without opening a duplicate. `ujust verify` adds post-fix evidence on real hardware and moves the issue toward closure.
 
+The Bonedigger caller is pinned to an immutable commit. Advance the pin whenever
+Bonedigger changes report-intake semantics so this workflow and the canonical
+bug-report template enforce the same data-donation contract.
+
 **`flow/agent-donation` issues:** write the report as a comment, cite sources, close the issue. Do not open a PR.
 
 ## Actionadon bot


### PR DESCRIPTION
## Summary
- pin Dakota to Bonedigger commit `7f2875210d89a170858f962cd6a089d4a813f214`
- document the invariant that caller pins advance with intake semantics

## Root cause
Dakota #1527 was not recognized as a data-bearing `ujust report`, so report-specific automation did not run.

## Validation
- `actionlint .github/workflows/bonedigger.yml`
- Runnable `just validate` checks passed: workflow checks, 126 Python tests, and render-card tests
- BuildStream graph checks were blocked because the local container adapter cannot mount this checkout (`statfs ...: no file directory`); CI will run them in its supported runner.