### PR TITLE
feat: add chairlift (Go/GTK4/Libadwaita system management tool)

### DIFF
--- a/elements/bluefin/chairlift.bst
+++ b/elements/bluefin/chairlift.bst
@@ -1,0 +1,52 @@
+kind: manual
+
+sources:
+- kind: tar
+  (?):
+  - arch == "x86_64":
+      url: github_files:projectbluefin/chairlift/releases/download/v0.12.0/chairlift_0.12.0_linux_amd64.tar.gz
+      ref: edd2835b39aac9407ff432a1033a84906f1cd7d636cb152ffe369506b574c9d4
+  - arch == "aarch64":
+      url: github_files:projectbluefin/chairlift/releases/download/v0.12.0/chairlift_0.12.0_linux_arm64.tar.gz
+      ref: 976692a36603536a8409bc250a2d651b5e5e3c958ef72ffc97e1ace9ab660659
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+depends:
+- gnome-build-meta.bst:sdk/gtk.bst
+- gnome-build-meta.bst:sdk/libadwaita.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 -t "%{install-root}%{bindir}" chairlift chairlift-updex-helper chairlift-ublue-helper
+  - |
+    install -Dm755 data/chairlift-wrapper.sh "%{install-root}%{bindir}/chairlift-wrapper"
+  - |
+    install -Dm644 data/io.projectbluefin.chairlift.desktop \
+      "%{install-root}%{datadir}/applications/io.projectbluefin.chairlift.desktop"
+  - |
+    install -Dm644 data/icons/hicolor/scalable/apps/io.projectbluefin.chairlift.svg \
+      "%{install-root}%{datadir}/icons/hicolor/scalable/apps/io.projectbluefin.chairlift.svg"
+    install -Dm644 data/icons/hicolor/scalable/apps/io.projectbluefin.chairlift-flower.svg \
+      "%{install-root}%{datadir}/icons/hicolor/scalable/apps/io.projectbluefin.chairlift-flower.svg"
+    install -Dm644 data/icons/hicolor/symbolic/apps/io.projectbluefin.chairlift-symbolic.svg \
+      "%{install-root}%{datadir}/icons/hicolor/symbolic/apps/io.projectbluefin.chairlift-symbolic.svg"
+  - |
+    install -Dm644 data/io.projectbluefin.chairlift.bootc.policy \
+      "%{install-root}%{datadir}/polkit-1/actions/io.projectbluefin.chairlift.bootc.policy"
+    install -Dm644 data/io.projectbluefin.chairlift.updex.policy \
+      "%{install-root}%{datadir}/polkit-1/actions/io.projectbluefin.chairlift.updex.policy"
+    install -Dm644 data/io.projectbluefin.chairlift.sysupdate.policy \
+      "%{install-root}%{datadir}/polkit-1/actions/io.projectbluefin.chairlift.sysupdate.policy"
+    install -Dm644 data/io.projectbluefin.chairlift.ublue.policy \
+      "%{install-root}%{datadir}/polkit-1/actions/io.projectbluefin.chairlift.ublue.policy"
+  - |
+    install -Dm644 config.yml "%{install-root}%{datadir}/chairlift/config.yml"
+    install -Dm644 channels.example.yml "%{install-root}%{datadir}/doc/chairlift/channels.example.yml"
+  - |
+    %{install-extra}

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -16,6 +16,7 @@ depends:
 
 
   - bluefin/ghostty.bst
+  - bluefin/chairlift.bst
 
   - bluefin/fastfetch.bst
   - bluefin/nerd-fonts-symbols.bst


### PR DESCRIPTION
## Summary
Adds [chairlift](https://github.com/projectbluefin/chairlift) — Homebrew package management, system health, and update UI, with testing-channel/developer-mode/gaming-mode switches ported from bluefinctl (self-hiding on any image without `/usr/share/ublue-os/image-info.json`, which Dakota has).

`elements/bluefin/chairlift.bst`: `kind: manual` + `kind: tar` sourcing the prebuilt per-arch release tarball, same pattern as `bluefin/gum.bst`. `build-depends`/`depends` mirror `bluefin/ghostty.bst`'s GTK4/Libadwaita dependency set.

Wired into `elements/bluefin/deps.bst` next to `ghostty.bst`.

## Verification
- `bst show bluefin/chairlift.bst` resolves the full dependency graph with no errors.
- `bst source fetch bluefin/chairlift.bst` successfully downloads and checksum-verifies the real `v0.12.0` release tarball from `github.com/projectbluefin/chairlift`.
- A full `bst build` was still in progress at PR time — a world rebuild can take hours per `docs/skills/bst-desktop-repos.md` — so this has **not yet been confirmed to build clean end to end**. Flagging that explicitly rather than merging on partial confidence.

## Test plan
- [ ] `bst build bluefin/chairlift.bst` succeeds
- [ ] Full image build succeeds with chairlift wired in
- [ ] chairlift launches from the app grid on a built image