### PR TITLE
fix(brew): migrate ChairLift off the Frostyard tap

### DIFF
--- a/.agents/skills/dakota-workstation/references/host-homebrew.md
+++ b/.agents/skills/dakota-workstation/references/host-homebrew.md
@@ -62,6 +62,111 @@ the source; `elements/bluefin/common.bst` keeps a build-time guard that fails
 if the `/var/home/linuxbrew` spelling ever regresses upstream — fix such
 regressions in common, not with a Dakota-side rewrite.
 
+## ChairLift cask migration
+
+Dakota installs `ublue-os/tap/chairlift` (Project Bluefin's release), not
+`frostyard/tap/chairlift`. `bluefin/common.bst` replaces the inherited Brewfile,
+desktop assets and bootc policy using pinned ChairLift source. Keep common's
+existing `/usr/share/chairlift/config.yml` unchanged: fork-only configuration keys
+make the old Frostyard binary reject the entire file if migration is offline or
+blocked. `/etc/chairlift` remains authoritative and untouched. New fork-only UI
+groups inherit the fork's defaults; this migration does not integrate their
+backends. Only the existing bootc staging capability is supplied, with unchanged
+admin requirements and `/usr/libexec/bootc-update-stage` path. No additional
+privileged helpers or policies are installed.
+
+`/usr/libexec/dakota-brew-managed preinstall` attempts the one-time migration,
+then runs generic preinstall **even if ChairLift fails**, passing common's
+`--external-chairlift` option. Common excludes `chairlift.Brewfile` from generic
+bundle/hash/removal handling; the dedicated installer owns both first install
+and migration. Other images retain common's normal behavior without the option.
+Generic preinstall must not silently install an unchecked ChairLift or remove it
+during this handoff.
+The wrapper returns failure when either part fails, so failures remain visible.
+
+The handoff implementation belongs in `projectbluefin/common`, not a downstream
+patch. Dakota's BST install checks common's `--capabilities` output for
+`external-chairlift-v1` before changing image files. The pinned common source
+includes this API. Keep that capability when updating the pin; the build rejects
+older common rather than letting generic preinstall bypass the dedicated
+installer.
+
+The brew update/upgrade services and uupd's `modules.brew.path` use the wrapper
+solely for shared-prefix locking. Native `update` and `upgrade` do not run the
+migration or inherit its no-auto-update/cleanup settings. A pinned ChairLift or
+failed migration cannot gate unrelated upgrades. Administrator overrides of uupd's
+Brew path must preserve that routing. Interactive Brew and ChairLift operations
+do not take this additional lock: close them while migrating; Homebrew's own
+package locks are not a transaction lock across the whole migration.
+
+The migration checks **installed receipts**, not the current tap definition, and
+requires a matching old OS-managed cask record before replacing an existing
+install (a Bluefin-qualified record cannot authorize a Frostyard cask). It captures
+that consent with the installed receipt's SHA256 before generic preinstall drops
+ChairLift from its managed set. Missing/corrupt state, third-party sources, pinned
+casks and unknown receipts stop rather than authorize a replacement. For a known
+legacy install that the user explicitly wants adopted, run as the prefix owner,
+without sudo:
+
+```bash
+/usr/libexec/dakota-brew-managed migrate-chairlift --adopt
+```
+
+First installs and replacements must resolve to a checksummed stable Project
+Bluefin release (numeric `x.y.z`, at least `0.12.2`, with the URL tag matching the
+version). `latest`, prereleases, stale Frostyard-backed casks and invalid checksums
+are rejected before uninstall. The download is verified before removing the old
+cask. A mode-0600 atomic checkpoint at
+`/home/linuxbrew/.linuxbrew/var/dakota-chairlift-migration.json` records schema 2
+phases `authorized`, `prepared`, `replacing`, and `complete`. Preparation freezes
+the target version, URL and checksum. A changed source receipt or prepared target
+requires inspection and explicit `--adopt` reauthorization, not blind retries.
+
+A `replacing` retry accepts the original receipt, absence after uninstall, or the
+expected target receipt. If that target lacks its versioned executable links,
+normal retry uses Homebrew's checksummed `reinstall` without `--zap`. A completed
+migration does not consult the moving candidate or implement future upgrades;
+Homebrew owns those. User removal is respected. Damage or a legacy reinstall after
+completion requires explicit adoption; completion is not perpetual consent.
+
+This is **not an atomic package transaction**: failure after uninstall temporarily
+leaves ChairLift unavailable. Fix the reported error and rerun the same command;
+do not delete checkpoints or fabricate preinstall state. Concurrent interactive
+Brew remains unsupported. The preinstall declaration remains in the image, but
+ChairLift is intentionally no longer in generic preinstall's OS-diet managed set.
+
+The migration removes `frostyard/tap`, but never force-uninstalls its packages.
+Every cask directory and formula version directory must have a readable provenance
+receipt; a missing receipt blocks removal too. Other installed Frostyard packages
+are reported before ChairLift is removed and must be deliberately migrated first.
+Duplicate names installed from the Bluefin tap are retained. Homebrew's
+`untap --force` can uninstall casks, so it is not used: after receipt checks prove
+no Frostyard packages remain, developer mode
+is scoped to the **untap command only**, allowing tap-only removal even when
+Homebrew confuses duplicate cask tokens. No persistent developer setting changes.
+See the verified [Homebrew untap implementation](https://github.com/Homebrew/brew/blob/05f17bafd849202efca55544c3312aae31a8fd23/Library/Homebrew/cmd/untap.rb),
+[installed-cask receipts](https://github.com/Homebrew/brew/blob/05f17bafd849202efca55544c3312aae31a8fd23/Library/Homebrew/cask/tab.rb),
+and [uupd's configurable Brew path](https://github.com/ublue-os/uupd/blob/v1.4.0/pkg/config/config.go).
+
+Image rollback does not roll back the persistent cask or checkpoint. Older Dakota
+images also carry the Frostyard Brewfile and can re-add that tap; do not run their
+preinstall/upgrade jobs as a migration rollback. Test image rollback with the
+Bluefin cask retained, or plan an explicit package rollback before deployment.
+The bootc helper path and authorization requirements stay compatible across the
+policy ID change. Automatic cask downgrade is intentionally not implemented.
+
+Validation: `just test-chairlift-migration` exercises receipt/ownership checks,
+one-time behavior, checkpoint identity, partial-install repair, fresh-source
+validation, tap removal, native-upgrade independence and BST installation using
+isolated Bash/jq fixtures. It also invokes common's opt-in API using a test-only
+snapshot, exercises generic preinstall ownership handoff, and rejects image
+assembly against old common. Refresh the snapshot from the landed common source
+when advancing the pin; fixtures never supply production image content.
+`just validate` includes it. Before shipping, additionally build
+`bluefin/common.bst` and boot-test a fresh install and a managed Frostyard upgrade,
+including an administrator config override and image rollback. Mock tests are
+not evidence of successful live cask migration or GUI/polkit operation.
+
 ## Repairing a bricked prefix on an installed system
 
 Do **not** delete the prefix (user packages live there) and do not reach for

--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,7 @@ check-publish-workflow:
     python3 -m unittest scripts.test_gen_filemap
     python3 -m unittest scripts.test_image_variants
     python3 -m unittest scripts.test_desktop_defaults
+    just test-chairlift-migration
 
 [group('dev')]
 monitor-pipeline BUILD_RUN_ID="":
@@ -104,6 +105,11 @@ validate:
     just test-render-card
     just bst show --deps all oci/bluefin.bst
     just bst show --deps all oci/bluefin-nvidia.bst
+
+# Offline migration/assembly checks; never invokes the host Homebrew.
+[group('test')]
+test-chairlift-migration:
+    bash scripts/test_chairlift_migration.sh
 
 # Unit tests for .github/scripts/render_card.py.
 [group('dev')]

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,8 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.08-90-g3676e24423bdf3f0603084b8be0719bb0a72573b
+  # Includes the external-chairlift-v1 handoff API; install.sh checks it.
+  ref: v2026.08-99-g5cb020bf868d5502cceb9ecd11ff859dd3a6c6e3
 # Consume common's fastfetch layout directly; only adapt the install-date input.
 # Drop this patch once common provides a shared install-date helper.
 - kind: patch
@@ -19,6 +20,16 @@ sources:
   ref: f5213ca61615bb79a8315fc4c5378a80ca93922e
 - kind: local
   path: files/wallpaper-month
+# Image-owned integration for the Bluefin Homebrew cask; no privileged
+# helper is installed from the user-writable Brew prefix.
+- kind: git_repo
+  url: github:projectbluefin/chairlift.git
+  track: v0.12.2
+  ref: 5e92e9bd6b24d641cabcff84d079f45532ca94ae
+  directory: chairlift-upstream
+- kind: local
+  path: files/chairlift
+  directory: dakota-chairlift
 
 build-depends:
 - core/sandbox-tools.bst
@@ -126,6 +137,10 @@ config:
     # Dakota uses its own ublue-motd (from motd.bst) with a double-display guard.
     # Remove common's umotd.sh hook to prevent dual MOTD on every login.
     rm -f "%{install-root}%{sysconfdir}/profile.d/umotd.sh"
+
+    # Replace common's legacy Frostyard declaration and integration, with
+    # a guarded preinstall migration for the persistent Homebrew prefix.
+    bash dakota-chairlift/install.sh "%{install-root}"
 
     # Add BudsLink to default system flatpaks
     echo 'flatpak "io.github.maniacx.BudsLink"' >> "%{install-root}%{datadir}/ublue-os/homebrew/system-flatpaks.Brewfile"

--- a/elements/bluefin/uupd.bst
+++ b/elements/bluefin/uupd.bst
@@ -94,7 +94,8 @@ config:
         },
         "modules": {
             "brew": {
-                "disable": false
+                "disable": false,
+                "path": "/usr/libexec/dakota-brew-managed"
             },
             "distrobox": {
                 "disable": false

--- a/files/chairlift/chairlift.Brewfile
+++ b/files/chairlift/chairlift.Brewfile
@@ -1,0 +1,2 @@
+tap "ublue-os/tap", trusted: true
+cask "ublue-os/tap/chairlift"

--- a/files/chairlift/dakota-brew-managed
+++ b/files/chairlift/dakota-brew-managed
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# One-time ChairLift migration and shared locking for Dakota-managed Brew jobs.
+# No root operations, --force/--zap, or changes to administrator configuration.
+set -euo pipefail
+
+PREFIX=/home/linuxbrew/.linuxbrew
+BREW_BIN=${PREFIX}/bin/brew
+PREINSTALL=/usr/libexec/brew-preinstall
+STATE_FILE=${HOME}/.local/share/ublue-os/brew-preinstall-state.json
+TARGET=ublue-os/tap/chairlift
+
+log() { printf 'dakota-brew-managed: %s\n' "$*" >&2; }
+
+# Receipts, never the mutable tap definition, identify the installed source.
+installed_chairlift() {
+    local directory=${PREFIX}/Caskroom/chairlift receipt digest
+    receipt=${directory}/.metadata/INSTALL_RECEIPT.json
+    if [[ ! -e "$directory" && ! -L "$directory" ]]; then
+        printf '{"tap":"absent","version":"","receipt":""}\n'
+        return
+    fi
+    digest=$(sha256sum "$receipt") || return 1
+    jq -ce --arg digest "${digest%% *}" '
+        .source | select(type == "object") |
+        select((.tap | type) == "string" and (.version | type) == "string") |
+        select(.tap != "" and (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) |
+        {tap, version, receipt:$digest}
+    ' "$receipt" || { log 'Cannot identify installed ChairLift; no replacement attempted.'; return 1; }
+}
+
+healthy_chairlift() {
+    local version binary resolved
+    version=$(jq -er '.source.version' "${PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json") || return 1
+    for binary in chairlift chairlift-wrapper; do
+        [[ -x ${PREFIX}/bin/${binary} ]] || return 1
+        resolved=$(readlink -e "${PREFIX}/bin/${binary}") || return 1
+        [[ "$resolved" == "${PREFIX}/Caskroom/chairlift/${version}/"* ]] || return 1
+    done
+}
+
+managed_chairlift() {
+    # A record for a DIFFERENT tap must never authorize a later manual install.
+    jq -e --arg name "$1/chairlift" '(.casks | type) == "array" and
+        any(.casks[]; . == "chairlift" or . == $name)' "$STATE_FILE" >/dev/null 2>&1
+}
+
+checkpoint() {
+    local file=${PREFIX}/var/dakota-chairlift-migration.json tmp
+    tmp=$(mktemp "${file}.XXXXXX") || return 1
+    if ! printf '%s\n' "$1" > "$tmp"; then rm -f "$tmp"; return 1; fi
+    mv -f "$tmp" "$file"
+}
+
+remove_frostyard_tap() {
+    local check_only=${1:-false} taps receipt tap directory version
+    taps=$("$BREW_BIN" tap) || return 1
+    if ! grep -Fxq frostyard/tap <<< "$taps"; then return 0; fi
+    local -a receipts=()
+    shopt -s nullglob
+    for directory in "${PREFIX}"/Caskroom/*; do
+        receipt=${directory}/.metadata/INSTALL_RECEIPT.json
+        [[ -d "$directory" && -f "$receipt" ]] || {
+            log "Unidentified cask: $directory; refusing to untap."; return 1;
+        }
+        receipts+=("$receipt")
+    done
+    # Enumerate version directories, NOT only matching receipt files. An
+    # installed keg without a receipt is unknown provenance, not absence.
+    for directory in "${PREFIX}"/Cellar/*; do
+        [[ -d "$directory" ]] || { log "Unidentified formula: $directory"; return 1; }
+        for version in "$directory"/*; do
+            receipt=${version}/INSTALL_RECEIPT.json
+            [[ -d "$version" && -f "$receipt" ]] || {
+                log "Unidentified keg: $version; refusing to untap."; return 1;
+            }
+            receipts+=("$receipt")
+        done
+    done
+    for receipt in "${receipts[@]}"; do
+        tap=$(jq -er '.source.tap | select(type == "string" and length > 0)' "$receipt") || {
+            log "Cannot determine package provenance: $receipt; refusing to untap."; return 1;
+        }
+        if [[ "$tap" == frostyard/tap ]]; then
+            if [[ "$check_only" == true && "$receipt" == "${PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json" ]]; then
+                continue
+            fi
+            log "Still installed from Frostyard: $receipt. Migrate this package before retrying."
+            return 1
+        fi
+    done
+    if [[ "$check_only" == true ]]; then return 0; fi
+    # Ordinary untap confuses duplicate cask tokens; --force can UNINSTALL
+    # packages. Developer-mode untap removes only the tap, after our scan.
+    # Homebrew/brew cmd/untap.rb at 05f17bafd849; never persist developer mode.
+    env -u HOMEBREW_NO_ASK HOMEBREW_DEVELOPER=1 "$BREW_BIN" untap frostyard/tap </dev/null || return 1
+    taps=$("$BREW_BIN" tap) || return 1
+    if grep -Fxq frostyard/tap <<< "$taps"; then
+        log 'Frostyard tap remains installed; migration is not complete.'
+        return 1
+    fi
+}
+
+candidate_chairlift() {
+    local candidate
+    candidate=$("$BREW_BIN" info --json=v2 --cask "$TARGET") || return 1
+    # The same stable x.y.z grammar is used for receipts and candidates.
+    # Reject stale Frostyard downloads, latest/prereleases and unchecked URLs
+    # BEFORE uninstall; bind the URL's release tag to the declared version.
+    jq -ce '
+        .casks | select(length == 1) | .[0] |
+        select(.token == "chairlift" and .tap == "ublue-os/tap") |
+        select((.version | type) == "string" and (.sha256 | type) == "string" and (.url | type) == "string") |
+        select(.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) |
+        select(.sha256 | test("^[a-f0-9]{64}$")) |
+        select(.url | test("^https://github.com/projectbluefin/chairlift/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+/[^/?#]+$")) |
+        {tap, version, sha256, url}
+    ' <<< "$candidate"
+}
+
+# A subshell confines Homebrew overrides to the migration; native updater and
+# generic preinstall retain their normal environment and file permissions.
+migrate_chairlift() (
+    export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTOREMOVE=1 HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_ASK=1
+    local adopt=${1:-false} installed tap version record phase source candidate after
+    local file=${PREFIX}/var/dakota-chairlift-migration.json
+    installed=$(installed_chairlift) || return 1
+    tap=$(jq -r .tap <<< "$installed")
+    version=$(jq -r .version <<< "$installed")
+    case "$tap" in
+        absent|frostyard/tap|ublue-os/tap) ;;
+        *) log "ChairLift belongs to $tap; refusing to replace a third-party cask."; return 1 ;;
+    esac
+    record=''
+    if [[ -e "$file" ]]; then
+        record=$(jq -ce '
+            def version: type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$");
+            def sha: type == "string" and test("^[a-f0-9]{64}$");
+            select(.schema == 2 and
+                (.phase == "authorized" or .phase == "prepared" or .phase == "replacing" or .phase == "complete")) |
+            select((.source.tap == "absent" and .source.version == "" and .source.receipt == "") or
+                ((.source.tap == "frostyard/tap" or .source.tap == "ublue-os/tap") and
+                 (.source.version | version) and (.source.receipt | sha))) |
+            select((.phase == "authorized" and .target == null) or
+                (.phase != "authorized" and .target.tap == "ublue-os/tap" and
+                 (.target.version | version) and (.target.sha256 | sha) and (.target.url | type) == "string"))
+        ' "$file") || { log 'Invalid migration checkpoint; inspect it before retrying.'; return 1; }
+        phase=$(jq -r .phase <<< "$record")
+        if [[ "$phase" == complete && "$adopt" == false ]]; then
+            # Completion is NOT consent to replace a later manual install, nor
+            # a request to resurrect a removed cask or implement future upgrades.
+            local completed_version
+            completed_version=$(jq -r '.target.version // ""' <<< "$record")
+            if [[ "$tap" != absent ]] && { [[ "$tap" != ublue-os/tap || -z "$completed_version" ||
+                $(printf '%s\n' "$completed_version" "$version" | sort -V | tail -n1) != "$version" ]] || ! healthy_chairlift; }; then
+                log 'ChairLift changed after migration; inspect it and use --adopt only if replacement is wanted.'
+                return 1
+            fi
+            remove_frostyard_tap
+            return $?
+        fi
+        if [[ "$adopt" == true ]]; then record=''; fi
+    fi
+    if [[ -z "$record" ]]; then
+        if [[ "$tap" != absent && "$adopt" == false ]] && ! managed_chairlift "$tap"; then
+            log 'ChairLift ownership is unclear; use migrate-chairlift --adopt to explicitly opt in.'
+            return 1
+        fi
+        record=$(jq -cn --argjson source "$installed" '{schema:2,phase:"authorized",source:$source,target:null}') || return 1
+        # Save consent BEFORE generic preinstall rewrites its managed set, even
+        # if the network or a pin blocks preparation. Bind it to this receipt.
+        checkpoint "$record" || return 1
+    fi
+    phase=$(jq -r .phase <<< "$record")
+    source=$(jq -c .source <<< "$record")
+    if [[ "$installed" != "$source" ]]; then
+        if [[ "$phase" != replacing ]] || ! jq -e --argjson installed "$installed" '
+            $installed.tap == "absent" or
+            ($installed.tap == .target.tap and $installed.version == .target.version)
+        ' <<< "$record" >/dev/null; then
+            log 'Installed receipt changed since authorization; inspect it before explicitly adopting again.'
+            return 1
+        fi
+    fi
+    if [[ -e ${PREFIX}/var/homebrew/pinned_casks/chairlift || -L ${PREFIX}/var/homebrew/pinned_casks/chairlift ]]; then
+        log 'ChairLift is pinned; unpin it explicitly before migrating.'; return 1
+    fi
+    "$BREW_BIN" tap ublue-os/tap || return 1
+    "$BREW_BIN" trust ublue-os/tap || return 1
+    candidate=$(candidate_chairlift) || { log 'Target cask is not a checksummed stable Project Bluefin release.'; return 1; }
+    local expected url
+    expected=$(jq -r .version <<< "$candidate")
+    url=$(jq -r .url <<< "$candidate")
+    [[ "$url" == "https://github.com/projectbluefin/chairlift/releases/download/v${expected}/"* &&
+        $(printf '%s\n' 0.12.2 "$expected" | sort -V | head -n1) == 0.12.2 ]] || {
+        log 'Target version/URL is inconsistent or predates the Bluefin release.'; return 1;
+    }
+    if [[ "$phase" != authorized && $(jq -c .target <<< "$record") != "$candidate" ]]; then
+        log 'Replacement changed since preparation; inspect the new cask and use --adopt to reauthorize.'; return 1
+    fi
+    remove_frostyard_tap true || return 1
+    # Existing healthy Bluefin installs need only tap cleanup. Never downgrade.
+    if [[ "$phase" == authorized && "$tap" == ublue-os/tap ]] && healthy_chairlift &&
+        [[ $(printf '%s\n' "$expected" "$version" | sort -V | tail -n1) == "$version" ]]; then
+        remove_frostyard_tap || return 1
+        record=$(jq -c --argjson target "$candidate" '.phase="complete" | .target=$target' <<< "$record") || return 1
+        checkpoint "$record"
+        return $?
+    fi
+    if [[ "$tap" == ublue-os/tap && "$version" != "$expected" &&
+        $(printf '%s\n' "$expected" "$version" | sort -V | tail -n1) == "$version" ]]; then
+        log 'Refusing to downgrade a partial newer Bluefin install; update the tap before repair.'; return 1
+    fi
+    "$BREW_BIN" fetch --cask "$TARGET" || return 1
+    if [[ $(candidate_chairlift) != "$candidate" ]]; then
+        log 'Target changed during download; no replacement attempted.'; return 1
+    fi
+    if [[ "$phase" == authorized ]]; then
+        record=$(jq -c --argjson target "$candidate" '.phase="prepared" | .target=$target' <<< "$record") || return 1
+        checkpoint "$record" || return 1
+    fi
+    record=$(jq -c '.phase="replacing"' <<< "$record") || return 1
+    checkpoint "$record" || return 1
+    # A receipt left by our interrupted target install is repairable. A
+    # different version/source above is NOT covered by the pending marker.
+    if [[ "$tap" == ublue-os/tap && "$version" == "$expected" ]]; then
+        if ! healthy_chairlift; then
+            "$BREW_BIN" reinstall --cask --require-sha "$TARGET" || return 1
+        fi
+    else
+        if [[ "$tap" != absent ]]; then
+            "$BREW_BIN" uninstall --cask "${tap}/chairlift" || return 1
+        fi
+        remove_frostyard_tap || return 1
+        if [[ $(candidate_chairlift) != "$candidate" ]]; then
+            log 'Target changed after uninstall; checkpoint retained, refusing a different replacement.'; return 1
+        fi
+        "$BREW_BIN" install --cask --require-sha "$TARGET" || return 1
+    fi
+    after=$(installed_chairlift) || return 1
+    if ! jq -e --arg version "$expected" '.tap == "ublue-os/tap" and .version == $version' <<< "$after" >/dev/null || ! healthy_chairlift; then
+        log 'Replacement verification failed; checkpoint retained for retry.'; return 1
+    fi
+    remove_frostyard_tap || return 1
+    record=$(jq -c '.phase="complete"' <<< "$record") || return 1
+    checkpoint "$record" || return 1
+    log 'ChairLift migrated and frostyard/tap removed. Settings and other packages were left alone.'
+)
+
+main() {
+    local command=${1:-} adopt=false migration_rc=0 preinstall_rc=0
+    case "$command" in
+        preinstall|update|upgrade) [[ $# == 1 ]] || return 2 ;;
+        migrate-chairlift)
+            if [[ $# == 2 && $2 == --adopt ]]; then adopt=true
+            elif [[ $# != 1 ]]; then return 2; fi ;;
+        *) log 'Usage: dakota-brew-managed {preinstall|update|upgrade|migrate-chairlift [--adopt]}'; return 2 ;;
+    esac
+    if [[ $EUID == 0 ]]; then log 'Run as the Homebrew owner, never root.'; return 1; fi
+    [[ -x "$BREW_BIN" ]] || { log 'Homebrew is unavailable; retry after setup.'; return 1; }
+    [[ $(stat -c %u "$PREFIX") == "$EUID" ]] || { log 'Run as the owner of the shared Homebrew prefix.'; return 1; }
+    mkdir -p "${PREFIX}/var" || return 1
+    exec 9> "${PREFIX}/var/dakota-brew-managed.lock"
+    flock -w 120 9 || { log 'Another managed Brew job is running; retry later.'; return 1; }
+    case "$command" in
+        update|upgrade) "$BREW_BIN" "$command" ;;
+        preinstall)
+            migrate_chairlift || migration_rc=$?
+            "$PREINSTALL" --external-chairlift || preinstall_rc=$?
+            if [[ $migration_rc != 0 ]]; then return "$migration_rc"; fi
+            return "$preinstall_rc" ;;
+        migrate-chairlift) migrate_chairlift "$adopt" ;;
+    esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then main "$@"; fi

--- a/files/chairlift/install.sh
+++ b/files/chairlift/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Runs inside bluefin/common.bst after common's files have been installed.
+# chairlift-upstream is a pinned Git source, never the writable Brew prefix.
+set -euo pipefail
+root=${1:?install root required}
+assets=chairlift-upstream/data
+local_files=dakota-chairlift
+brewfile=${root}/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile
+
+# Require common's upstream handoff API before changing any image files;
+# an older common pin must not silently ignore the flag.
+if [[ $(bash "${root}/usr/libexec/brew-preinstall" --capabilities) != external-chairlift-v1 ]]; then
+    echo 'Common lacks external-chairlift-v1; use a common pin that includes the handoff API.' >&2
+    exit 1
+fi
+
+# Stop rather than silently overriding a future upstream migration. Common
+# has shipped both unqualified and Frostyard-qualified versions of this cask.
+mapfile -t old < "$brewfile"
+if [[ ${#old[@]} != 2 || ${old[0]} != 'tap "frostyard/tap", trusted: true' ||
+      ( ${old[1]} != 'cask "chairlift"' && ${old[1]} != 'cask "frostyard/tap/chairlift"' ) ]]; then
+    echo 'ChairLift preinstall changed in common; reconcile the Dakota migration.' >&2
+    exit 1
+fi
+install -Dm644 "${local_files}/chairlift.Brewfile" "$brewfile"
+install -Dm755 "${local_files}/dakota-brew-managed" "${root}/usr/libexec/dakota-brew-managed"
+# Replace the public entry point so manual brew-preinstall and its existing
+# user service both acquire the same lock and run the migration first.
+printf '#!/bin/sh\nexec /usr/libexec/dakota-brew-managed preinstall "$@"\n' > "${root}/usr/bin/brew-preinstall"
+chmod 755 "${root}/usr/bin/brew-preinstall"
+for operation in update upgrade; do
+    install -d "${root}/usr/lib/systemd/system/brew-${operation}.service.d"
+    printf '[Service]\nExecStart=\nExecStart=/usr/libexec/dakota-brew-managed %s\n' "$operation" \
+        > "${root}/usr/lib/systemd/system/brew-${operation}.service.d/dakota-managed.conf"
+done
+
+# Only the existing bootc staging capability is provided. Do not install the
+# ublue/updex/sysupdate helpers or policies as part of a cask migration.
+rm -f "${root}/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy"
+install -Dm644 "${assets}/io.projectbluefin.chairlift.bootc.policy" \
+    "${root}/usr/share/polkit-1/actions/io.projectbluefin.chairlift.bootc.policy"
+rm -f "${root}/usr/share/applications/org.frostyard.ChairLift.desktop"
+install -Dm644 "${assets}/io.projectbluefin.chairlift.desktop" \
+    "${root}/usr/share/applications/io.projectbluefin.chairlift.desktop"
+sed -i 's|^Exec=chairlift-wrapper$|Exec=/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper|' \
+    "${root}/usr/share/applications/io.projectbluefin.chairlift.desktop"
+for icon in scalable/apps/io.projectbluefin.chairlift.svg \
+    scalable/apps/io.projectbluefin.chairlift-flower.svg symbolic/apps/io.projectbluefin.chairlift-symbolic.svg; do
+    install -Dm644 "${assets}/icons/hicolor/${icon}" "${root}/usr/share/icons/hicolor/${icon}"
+done
+rm -f "${root}/usr/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg" \
+    "${root}/usr/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg" \
+    "${root}/usr/share/icons/hicolor/symbolic/apps/org.frostyard.ChairLift-symbolic.svg"
+# Keep common's existing shared-schema /usr/share/chairlift/config.yml:
+# fork-only keys make the old Frostyard binary reject the entire config when
+# migration is offline/blocked. /etc/chairlift belongs to the administrator.
+# New fork-only groups use the fork's defaults; no extra helpers are installed.

--- a/scripts/fixtures/README.md
+++ b/scripts/fixtures/README.md
@@ -1,0 +1,17 @@
+# ChairLift migration fixtures
+
+- `chairlift-brew` is an offline Bash test double. It operates only under the
+  test's temporary prefix and never delegates to real Homebrew.
+- `common-brew-preinstall` is an unmodified, test-only snapshot of
+  `projectbluefin/common` at `5cb020bf868d5502cceb9ecd11ff859dd3a6c6e3`, path
+  `system_files/shared/usr/libexec/brew-preinstall` (Apache-2.0 upstream).
+  It supplies the `--external-chairlift` API merged in common #1100.
+  It is not installed in the image and is not a downstream source patch.
+  When advancing Dakota's common pin, refresh this snapshot and its reference
+  from the same committed revision. The BST install guard rejects common
+  without `external-chairlift-v1`.
+
+The suite redirects the fixture's filesystem constants inside a temporary copy
+and runs it against the mock Brew. These tests do not establish that live cask
+hooks, GNOME launchers, or polkit work. Fresh-install, migration, offline failure,
+and rollback boot tests remain required before deployment.

--- a/scripts/fixtures/chairlift-brew
+++ b/scripts/fixtures/chairlift-brew
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Offline test double. Never delegates to the host's real Homebrew.
+set -euo pipefail
+: "${FIXTURE:?}" "${MOCK_PREFIX:?}"
+printf '%s\n' "$*" >> "${FIXTURE}/commands"
+if [[ ${HOMEBREW_DEVELOPER:-} == 1 ]]; then printf '%s\n' "$*" >> "${FIXTURE}/developer-commands"; fi
+case "$*" in
+    tap)
+        printf 'ublue-os/tap\n'
+        if [[ -e ${FIXTURE}/frostyard ]]; then printf 'frostyard/tap\n'; fi ;;
+    'tap ublue-os/tap'|'trust ublue-os/tap')
+        [[ ! -e ${FIXTURE}/tap-fail ]] ;;
+    'info --json=v2 --cask ublue-os/tap/chairlift')
+        if [[ -e ${FIXTURE}/info-fail ]]; then exit 1; fi
+        jq -n --arg url "$(< "${FIXTURE}/target-url")" --arg sha "$(< "${FIXTURE}/target-sha")" \
+            --arg version "$(< "${FIXTURE}/target-version")" \
+            '{casks:[{token:"chairlift",tap:"ublue-os/tap",version:$version,sha256:$sha,url:$url}]}' ;;
+    'fetch --cask ublue-os/tap/chairlift')
+        [[ ! -e ${FIXTURE}/fetch-fail ]] || exit 1
+        if [[ -e ${FIXTURE}/change-during-fetch ]]; then
+            printf '%064d\n' 2 > "${FIXTURE}/target-sha"
+        fi ;;
+    'uninstall --cask frostyard/tap/chairlift'|'uninstall --cask ublue-os/tap/chairlift')
+        [[ ! -e ${FIXTURE}/uninstall-fail ]] || exit 1
+        rm -rf "${MOCK_PREFIX}/Caskroom/chairlift"
+        rm -f "${MOCK_PREFIX}/bin/chairlift" "${MOCK_PREFIX}/bin/chairlift-wrapper"
+        if [[ -e ${FIXTURE}/change-during-uninstall ]]; then
+            printf '%064d\n' 2 > "${FIXTURE}/target-sha"
+        fi ;;
+    'untap frostyard/tap')
+        [[ ${HOMEBREW_DEVELOPER:-} == 1 ]] || exit 90
+        [[ ! -e ${FIXTURE}/untap-fail ]] || exit 1
+        [[ -e ${FIXTURE}/untap-noop ]] || rm -f "${FIXTURE}/frostyard" ;;
+    'install --cask --require-sha ublue-os/tap/chairlift'|'reinstall --cask --require-sha ublue-os/tap/chairlift')
+        [[ ! -e ${FIXTURE}/install-fail ]] || exit 1
+        mkdir -p "${MOCK_PREFIX}/Caskroom/chairlift/.metadata"
+        jq -n --arg version "$(< "${FIXTURE}/target-version")" \
+            '{source:{tap:"ublue-os/tap",version:$version}}' \
+            > "${MOCK_PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json"
+        if [[ -e ${FIXTURE}/wrong-receipt ]]; then
+            printf '{"source":{"tap":"frostyard/tap","version":"0.10.1"}}\n' \
+                > "${MOCK_PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json"
+        fi
+        if [[ ! -e ${FIXTURE}/missing-binaries ]]; then
+            version=$(< "${FIXTURE}/target-version")
+            mkdir -p "${MOCK_PREFIX}/Caskroom/chairlift/${version}"
+            for binary in chairlift chairlift-wrapper; do
+                printf '#!/bin/sh\nexit 0\n' > "${MOCK_PREFIX}/Caskroom/chairlift/${version}/${binary}"
+                chmod +x "${MOCK_PREFIX}/Caskroom/chairlift/${version}/${binary}"
+                ln -sfn "${MOCK_PREFIX}/Caskroom/chairlift/${version}/${binary}" "${MOCK_PREFIX}/bin/${binary}"
+            done
+        fi ;;
+    shellenv)
+        # Expanded by the generic preinstall's eval, not by this mock shell.
+        # shellcheck disable=SC2016
+        printf 'export PATH="%s/bin:$PATH"\n' "$MOCK_PREFIX" ;;
+    bundle*)
+        [[ "$*" != *chairlift.Brewfile* ]] || exit 91
+        [[ ${HOMEBREW_NO_AUTO_UPDATE:-} != 1 ]] || exit 92 ;;
+    update)
+        [[ ${HOMEBREW_NO_AUTO_UPDATE:-} != 1 ]] || exit 92
+        [[ $(umask) != 0077 ]] || exit 93
+        if [[ -p ${FIXTURE}/update-ready ]]; then
+            printf 'ready\n' > "${FIXTURE}/update-ready"
+            read -r _ < "${FIXTURE}/update-release"
+        fi ;;
+    upgrade)
+        [[ ${HOMEBREW_NO_AUTO_UPDATE:-} != 1 ]] || exit 92
+        [[ $(umask) != 0077 ]] || exit 93 ;;
+    *) printf 'Unexpected mock brew invocation: %s\n' "$*" >&2; exit 99 ;;
+esac

--- a/scripts/fixtures/common-brew-preinstall
+++ b/scripts/fixtures/common-brew-preinstall
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# brew-preinstall — content-addressed install/remove of OS-managed Homebrew packages.
+#
+# Triggered by hash change across preinstall.d/*.Brewfile, not a manual version bump.
+# Handles the full package lifecycle: new packages added by OS updates are installed,
+# packages removed from Brewfiles are uninstalled — without touching user-added packages.
+#
+# State: ~/.local/share/ublue-os/brew-preinstall-state.json
+#   { "hash": "<sha256 of all Brewfiles>",
+#     "packages": ["pkg1", "pkg2", ...],
+#     "casks": ["cask1", ...] }
+# Older state files without a "casks" key are read as an empty cask list.
+set -euo pipefail
+
+# Opt-in handoff for images with a dedicated ChairLift installer. Other images
+# retain the normal bundle/install/remove lifecycle with no arguments.
+external_chairlift=0
+case "$*" in
+    '') ;;
+    --external-chairlift) external_chairlift=1 ;;
+    --capabilities) printf '%s\n' external-chairlift-v1; exit 0 ;;
+    *) echo 'Usage: brew-preinstall [--external-chairlift|--capabilities]' >&2; exit 2 ;;
+esac
+
+PREINSTALL_DIR="/usr/share/ublue-os/homebrew/preinstall.d"
+STATE_FILE="${HOME}/.local/share/ublue-os/brew-preinstall-state.json"
+BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
+
+if [[ ! -x "${BREW_BIN}" ]]; then
+    echo "brew-preinstall: brew not found at ${BREW_BIN}, skipping"
+    exit 0
+fi
+
+if [[ ! -d "${PREINSTALL_DIR}" ]]; then
+    echo "brew-preinstall: no preinstall.d at ${PREINSTALL_DIR}, skipping"
+    exit 0
+fi
+
+shopt -s nullglob
+# A dedicated installer owns the whole ChairLift Brewfile when requested,
+# including taps, hash, bundle and managed state. Never partially bundle it.
+brewfiles=()
+for brewfile in "${PREINSTALL_DIR}"/*.Brewfile; do
+    if [[ "${external_chairlift}" -eq 1 && "${brewfile##*/}" == chairlift.Brewfile ]]; then
+        continue
+    fi
+    brewfiles+=("${brewfile}")
+done
+
+if [[ ${#brewfiles[@]} -eq 0 ]]; then
+    echo "brew-preinstall: no Brewfiles in ${PREINSTALL_DIR}, skipping"
+    exit 0
+fi
+
+eval "$("${BREW_BIN}" shellenv)"
+
+# Install every tap before any bundle runs. brew bundle decides cask
+# installability before processing the Brewfile's own tap lines, so on a
+# system that has never seen the tap it skips the cask as "requires macOS"
+# and still exits 0 — the cask is silently never installed (first boot of
+# any image shipping a tap+cask pair, e.g. frostyard/tap + chairlift).
+# Vendored taps are also trusted: brew refuses casks from untrusted taps,
+# and the Brewfile's own `trusted:` flag doesn't apply to an already-present
+# tap. This runs every boot, before the hash early-exit, because
+# `brew bundle cleanup` resets the global trust store; both commands are
+# idempotent no-ops once the tap is present and trusted.
+tap_failed=0
+while IFS= read -r tap; do
+    [[ -z "${tap}" ]] && continue
+    if ! brew tap "${tap}"; then
+        echo "brew-preinstall: error: tapping ${tap} failed"
+        tap_failed=1
+    elif ! brew trust "${tap}"; then
+        echo "brew-preinstall: error: trusting ${tap} failed"
+        tap_failed=1
+    fi
+done < <(sed -nE \
+    -e "s/^[[:space:]]*tap[[:space:]]+\"([^\"]+)\".*/\\1/p" \
+    -e "s/^[[:space:]]*tap[[:space:]]+'([^']+)'.*/\\1/p" \
+    "${brewfiles[@]}" | sort -u)
+
+if [[ "${tap_failed}" -ne 0 ]]; then
+    echo "brew-preinstall: one or more taps failed; state unchanged, will retry"
+    exit 1
+fi
+
+# Content-addressed check: hash all Brewfiles combined.
+# If unchanged, nothing else to do — fast exit without touching bundle.
+current_hash=$(cat "${brewfiles[@]}" | sha256sum | cut -d' ' -f1)
+stored_hash=$(jq -r '.hash // ""' "${STATE_FILE}" 2>/dev/null || echo "")
+
+if [[ "${current_hash}" == "${stored_hash}" ]]; then
+    echo "brew-preinstall: Brewfiles unchanged (${current_hash:0:12}...), nothing to do"
+    exit 0
+fi
+
+echo "brew-preinstall: Brewfiles changed (${current_hash:0:12}...), applying..."
+
+# Install all packages declared in Brewfiles (brew bundle is idempotent).
+# Continue after an individual failure so independent Brewfiles still install,
+# but leave state untouched so the complete run is retried.
+bundle_failed=0
+for brewfile in "${brewfiles[@]}"; do
+    echo "brew-preinstall: bundling ${brewfile}"
+    # Capture output for the skipped-cask check, then echo it. Do NOT pipe
+    # through `tee /dev/stderr`: under systemd, fd 2 is a journal socket and
+    # opening /dev/stderr fails with ENXIO, failing every bundle.
+    bundle_rc=0
+    bundle_output=$(brew bundle --file="${brewfile}" 2>&1) || bundle_rc=$?
+    printf '%s\n' "${bundle_output}"
+    if [[ "${bundle_rc}" -ne 0 ]]; then
+        echo "brew-preinstall: error: bundling ${brewfile} failed"
+        bundle_failed=1
+    fi
+    # A skipped cask is a silent no-op that exits 0; treat it as a failure
+    # so state stays unstamped and the run retries instead of never.
+    if grep -q "^Skipping cask" <<< "${bundle_output}"; then
+        echo "brew-preinstall: error: ${brewfile} skipped a cask; treating as failure"
+        bundle_failed=1
+    fi
+done
+
+if [[ "${bundle_failed}" -ne 0 ]]; then
+    echo "brew-preinstall: one or more Brewfiles failed; state unchanged, will retry"
+    exit 1
+fi
+
+# Uninstall packages and casks removed from our managed set (OS diet).
+# Parse the names we manage now vs what we managed before, then remove
+# the delta — but only if brew still has them installed.
+# This never touches packages the user added outside our managed set.
+current_packages=$(
+    sed -nE \
+        -e "s/^[[:space:]]*brew[[:space:]]+\"([^\"]+)\".*/\\1/p" \
+        -e "s/^[[:space:]]*brew[[:space:]]+'([^']+)'.*/\\1/p" \
+        "${brewfiles[@]}" | sort -u
+)
+current_casks=$(
+    sed -nE \
+        -e "s/^[[:space:]]*cask[[:space:]]+\"([^\"]+)\".*/\\1/p" \
+        -e "s/^[[:space:]]*cask[[:space:]]+'([^']+)'.*/\\1/p" \
+        "${brewfiles[@]}" | sort -u
+)
+
+if [[ -f "${STATE_FILE}" ]] && ! jq -e . "${STATE_FILE}" >/dev/null 2>&1; then
+    echo "brew-preinstall: warning: state file is corrupt; skipping removals this run and rebuilding state"
+fi
+
+previous_packages=$(jq -r '.packages[]? // empty' "${STATE_FILE}" 2>/dev/null \
+    | sort -u || true)
+# Hand ChairLift ownership to the caller, not the OS-diet remover. This must
+# work even if the old Brewfile has already disappeared from the new image.
+previous_casks=$(jq -r --argjson external "${external_chairlift}" '
+    .casks[]? // empty |
+    select($external == 0 or (. != "chairlift" and . != "frostyard/tap/chairlift" and . != "ublue-os/tap/chairlift"))
+' "${STATE_FILE}" 2>/dev/null \
+    | sort -u || true)
+
+managed_name_present() {
+    local candidate="${1##*/}"
+    local managed
+
+    while IFS= read -r managed; do
+        if [[ -n "${managed}" && "${managed##*/}" == "${candidate}" ]]; then
+            return 0
+        fi
+    done <<< "$2"
+
+    return 1
+}
+
+uninstall_failed=0
+
+if [[ -n "${previous_packages}" ]]; then
+    removed=$(comm -23 \
+        <(echo "${previous_packages}") \
+        <(echo "${current_packages}") || true)
+    for pkg in ${removed}; do
+        if managed_name_present "${pkg}" "${current_packages}"; then
+            continue
+        fi
+        if brew list --formula "${pkg}" &>/dev/null; then
+            echo "brew-preinstall: removing ${pkg} (dropped from managed set)"
+            brew uninstall "${pkg}" --ignore-dependencies \
+                || { echo "brew-preinstall: error: could not remove ${pkg}"; uninstall_failed=1; }
+        fi
+    done
+fi
+
+if [[ -n "${previous_casks}" ]]; then
+    removed_casks=$(comm -23 \
+        <(echo "${previous_casks}") \
+        <(echo "${current_casks}") || true)
+    for cask in ${removed_casks}; do
+        if managed_name_present "${cask}" "${current_casks}"; then
+            continue
+        fi
+        if brew list --cask "${cask}" &>/dev/null; then
+            echo "brew-preinstall: removing cask ${cask} (dropped from managed set)"
+            brew uninstall --cask "${cask}" \
+                || { echo "brew-preinstall: error: could not remove cask ${cask}"; uninstall_failed=1; }
+        fi
+    done
+fi
+
+if [[ "${uninstall_failed}" -ne 0 ]]; then
+    echo "brew-preinstall: one or more removals failed; state unchanged, will retry"
+    exit 1
+fi
+
+# Persist new state: hash + full managed package and cask lists for next diff.
+# Write atomically via temp file + rename to avoid corrupt state on SIGKILL.
+mkdir -p "$(dirname "${STATE_FILE}")"
+packages_json=$(echo "${current_packages}" | jq -R . | jq -s 'map(select(length > 0))')
+casks_json=$(echo "${current_casks}" | jq -R . | jq -s 'map(select(length > 0))')
+jq -n \
+    --arg hash "${current_hash}" \
+    --argjson packages "${packages_json}" \
+    --argjson casks "${casks_json}" \
+    '{"hash": $hash, "packages": $packages, "casks": $casks}' > "${STATE_FILE}.tmp"
+mv -f "${STATE_FILE}.tmp" "${STATE_FILE}"
+
+echo "brew-preinstall: complete"

--- a/scripts/test_chairlift_migration.sh
+++ b/scripts/test_chairlift_migration.sh
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+# Offline Bash/jq tests; no Brew commands, network, sudo, or host state changes.
+# Single-quoted programs deliberately expand in the isolated child shell.
+# shellcheck disable=SC2016
+set -euo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+reset_fixture() {
+    FIXTURE=$(mktemp -d "${WORK}/case.XXXXXX")
+    MOCK_PREFIX=${FIXTURE}/prefix
+    export FIXTURE MOCK_PREFIX
+    mkdir -p "${MOCK_PREFIX}/bin" "${MOCK_PREFIX}/var" "${MOCK_PREFIX}/Caskroom" "${MOCK_PREFIX}/Cellar"
+    cp "${ROOT}/scripts/fixtures/chairlift-brew" "${MOCK_PREFIX}/bin/brew"
+    chmod +x "${MOCK_PREFIX}/bin/brew"
+    : > "${FIXTURE}/commands"
+    : > "${FIXTURE}/frostyard"
+    printf '0.12.2\n' > "${FIXTURE}/target-version"
+    printf '%064d\n' 1 > "${FIXTURE}/target-sha"
+    printf 'https://github.com/projectbluefin/chairlift/releases/download/v0.12.2/chairlift_0.12.2_linux_amd64.tar.gz\n' > "${FIXTURE}/target-url"
+    printf '{"hash":"previous","packages":["jq"],"casks":["chairlift"]}\n' > "${FIXTURE}/state.json"
+    printf 'keep administrator config\n' > "${FIXTURE}/config.yml"
+    printf 'keep user settings\n' > "${FIXTURE}/settings"
+}
+
+receipt() {
+    local tap=${1:-frostyard/tap} version=${2:-0.10.1} name=${3:-chairlift}
+    mkdir -p "${MOCK_PREFIX}/Caskroom/${name}/.metadata"
+    jq -n --arg tap "$tap" --arg version "$version" '{source:{tap:$tap,version:$version}}' \
+        > "${MOCK_PREFIX}/Caskroom/${name}/.metadata/INSTALL_RECEIPT.json"
+    if [[ "$name" == chairlift ]]; then
+        mkdir -p "${MOCK_PREFIX}/Caskroom/chairlift/${version}"
+        for binary in chairlift chairlift-wrapper; do
+            printf '#!/bin/sh\nexit 0\n' > "${MOCK_PREFIX}/Caskroom/chairlift/${version}/${binary}"
+            chmod +x "${MOCK_PREFIX}/Caskroom/chairlift/${version}/${binary}"
+            ln -sfn "${MOCK_PREFIX}/Caskroom/chairlift/${version}/${binary}" "${MOCK_PREFIX}/bin/${binary}"
+        done
+    fi
+}
+
+run_migration() {
+    local adopt=${1:-false}
+    # Source the real functions, overriding only filesystem locations in this
+    # isolated process. Production has no environment-based path overrides.
+    bash -c '
+        source "$1/files/chairlift/dakota-brew-managed"
+        PREFIX=$MOCK_PREFIX
+        BREW_BIN=$PREFIX/bin/brew
+        STATE_FILE=$FIXTURE/state.json
+        migrate_chairlift "$2"
+    ' -- "$ROOT" "$adopt" > "${FIXTURE}/output" 2>&1
+}
+
+has_command() { grep -Fxq -- "$1" "${FIXTURE}/commands"; }
+no_command() { ! has_command "$1"; }
+phase() { jq -er --arg phase "$1" '.phase == $phase' "${MOCK_PREFIX}/var/dakota-chairlift-migration.json" >/dev/null; }
+check() {
+    local title=$1
+    shift
+    if "$@"; then printf 'ok - %s\n' "$title"
+    else printf 'FAIL - %s\n' "$title" >&2; printf 'Fixture: %s\n' "$FIXTURE" >&2; exit 1; fi
+}
+
+reset_fixture
+check 'fresh install removes stale tap' run_migration
+check 'fresh install uses validated dedicated installer' has_command 'install --cask --require-sha ublue-os/tap/chairlift'
+check 'fresh install untaps Frostyard' test ! -e "${FIXTURE}/frostyard"
+
+reset_fixture
+receipt
+check 'managed Frostyard migrates' run_migration
+check 'replacement receipt is Bluefin' jq -e '.source.tap == "ublue-os/tap"' "${MOCK_PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json"
+check 'complete checkpoint' phase complete
+check 'tap removed' test ! -e "${FIXTURE}/frostyard"
+check 'untap alone gets developer mode' test "$(< "${FIXTURE}/developer-commands")" = 'untap frostyard/tap'
+check 'order is fetch, uninstall, untap, install' bash -c '
+    actual=$(grep -E "^(fetch|uninstall|untap|install) " "$1/commands" | cut -d " " -f1)
+    [[ "$actual" == $'"'"'fetch\nuninstall\nuntap\ninstall'"'"' ]]
+' -- "$FIXTURE"
+check 'preinstall state not rewritten by migration' jq -e '.hash == "previous" and .packages == ["jq"] and .casks == ["chairlift"]' "${FIXTURE}/state.json"
+check 'admin config unchanged' test "$(< "${FIXTURE}/config.yml")" = 'keep administrator config'
+check 'user settings unchanged' test "$(< "${FIXTURE}/settings")" = 'keep user settings'
+: > "${FIXTURE}/commands"
+check 'repeat run succeeds' run_migration
+check 'repeat never uninstalls' no_command 'uninstall --cask ublue-os/tap/chairlift'
+check 'repeat never installs' no_command 'install --cask --require-sha ublue-os/tap/chairlift'
+
+reset_fixture
+receipt ublue-os/tap 0.12.2
+receipt ublue-os/tap 1 wallpapers
+check 'already Bluefin removes duplicate Frostyard tap without removing other casks' run_migration
+check 'duplicate wallpaper receipt survives' test -f "${MOCK_PREFIX}/Caskroom/wallpapers/.metadata/INSTALL_RECEIPT.json"
+check 'already Bluefin not uninstalled' no_command 'uninstall --cask ublue-os/tap/chairlift'
+
+reset_fixture
+receipt
+rm "${FIXTURE}/state.json"
+check 'unmanaged legacy blocks' bash -c '! "$@"' -- bash -c '
+    source "$1/files/chairlift/dakota-brew-managed"
+    PREFIX=$MOCK_PREFIX BREW_BIN=$MOCK_PREFIX/bin/brew STATE_FILE=$FIXTURE/state.json
+    migrate_chairlift
+' -- "$ROOT"
+check 'unmanaged legacy not uninstalled' no_command 'uninstall --cask frostyard/tap/chairlift'
+check 'explicit adoption works' run_migration true
+
+reset_fixture
+receipt third-party/tap 9
+if run_migration true; then check 'third-party source rejected even with adoption' false; fi
+check 'third-party install preserved' test -f "${MOCK_PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json"
+
+for failure in fetch-fail tap-fail info-fail; do
+    reset_fixture
+    receipt
+    : > "${FIXTURE}/${failure}"
+    if run_migration; then check "${failure} fails" false; fi
+    check "${failure} preserves old install" no_command 'uninstall --cask frostyard/tap/chairlift'
+    check "${failure} leaves tap" test -e "${FIXTURE}/frostyard"
+done
+
+for field in target-url target-sha; do
+    reset_fixture
+    receipt
+    printf 'invalid\n' > "${FIXTURE}/${field}"
+    if run_migration; then check "invalid ${field} fails closed" false; fi
+    check "invalid ${field} preserves old install" no_command 'uninstall --cask frostyard/tap/chairlift'
+done
+
+reset_fixture
+receipt
+: > "${FIXTURE}/install-fail"
+if run_migration; then check 'install failure propagates' false; fi
+check 'failed install keeps pending checkpoint' phase replacing
+rm "${FIXTURE}/install-fail" "${FIXTURE}/state.json"
+check 'resume after uninstall works without old OS state' run_migration
+check 'resume completes' phase complete
+
+reset_fixture
+receipt
+: > "${FIXTURE}/uninstall-fail"
+if run_migration; then check 'uninstall failure propagates' false; fi
+check 'uninstall failure never installs over legacy' no_command 'install --cask --require-sha ublue-os/tap/chairlift'
+check 'uninstall failure leaves tap' test -e "${FIXTURE}/frostyard"
+rm "${FIXTURE}/uninstall-fail"
+check 'retry failed uninstall' run_migration
+
+for failure in wrong-receipt missing-binaries untap-fail untap-noop; do
+    reset_fixture
+    receipt
+    : > "${FIXTURE}/${failure}"
+    if run_migration; then check "${failure} fails verification" false; fi
+    check "${failure} never stamps complete" phase replacing
+done
+
+reset_fixture
+receipt
+receipt frostyard/tap 1 wallpapers
+if run_migration; then check 'other Frostyard cask blocks removal' false; fi
+check 'other Frostyard cask stops before uninstalling ChairLift' no_command 'uninstall --cask frostyard/tap/chairlift'
+check 'other Frostyard cask not uninstalled' no_command 'uninstall --cask frostyard/tap/wallpapers'
+
+reset_fixture
+receipt
+mkdir -p "${MOCK_PREFIX}/Cellar/something/1"
+printf '{"source":{"tap":"frostyard/tap"}}\n' > "${MOCK_PREFIX}/Cellar/something/1/INSTALL_RECEIPT.json"
+if run_migration; then check 'Frostyard formula blocks removal' false; fi
+check 'Frostyard formula stops before uninstalling ChairLift' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+reset_fixture
+receipt
+printf 'broken\n' > "${MOCK_PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json"
+if run_migration; then check 'corrupt receipt fails closed' false; fi
+check 'corrupt receipt never treated as absent' no_command 'untap frostyard/tap'
+
+reset_fixture
+receipt
+printf 'broken\n' > "${FIXTURE}/state.json"
+if run_migration; then check 'corrupt managed state requires adoption' false; fi
+check 'corrupt state preserves old cask' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+reset_fixture
+receipt
+printf '{}\n' > "${MOCK_PREFIX}/var/dakota-chairlift-migration.json"
+if run_migration; then check 'invalid checkpoint rejected' false; fi
+check 'invalid checkpoint preserves old cask' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+reset_fixture
+receipt
+# Exercise the production wrapper, including the shared prefix lock, with
+# only paths redirected. The prefix owner check uses the real non-root UID.
+if [[ $EUID != 0 ]]; then
+    printf '#!/bin/sh\nprintf "preinstall\\n" >> "$FIXTURE/commands"\n' > "${FIXTURE}/preinstall"
+    chmod +x "${FIXTURE}/preinstall"
+    check 'wrapper migrates before normal preinstall' bash -c '
+        source "$1/files/chairlift/dakota-brew-managed"
+        PREFIX=$MOCK_PREFIX BREW_BIN=$MOCK_PREFIX/bin/brew STATE_FILE=$FIXTURE/state.json PREINSTALL=$FIXTURE/preinstall
+        main preinstall
+    ' -- "$ROOT"
+    check 'normal preinstall runs last' test "$(tail -n1 "${FIXTURE}/commands")" = preinstall
+    : > "${FIXTURE}/commands"
+    : > "${FIXTURE}/frostyard"
+    receipt
+    check 'upgrade is independent of migration' bash -c '
+        source "$1/files/chairlift/dakota-brew-managed"
+        PREFIX=$MOCK_PREFIX BREW_BIN=$MOCK_PREFIX/bin/brew STATE_FILE=$FIXTURE/state.json
+        main upgrade
+    ' -- "$ROOT"
+    check 'upgrade runs without migration' test "$(< "${FIXTURE}/commands")" = upgrade
+    mkfifo "${FIXTURE}/update-ready" "${FIXTURE}/update-release"
+    exec 8<> "${FIXTURE}/update-ready"
+    exec 7<> "${FIXTURE}/update-release"
+    timeout 10 bash -c '
+        source "$1/files/chairlift/dakota-brew-managed"
+        PREFIX=$MOCK_PREFIX BREW_BIN=$MOCK_PREFIX/bin/brew
+        main update
+    ' -- "$ROOT" &
+    update_pid=$!
+    if ! read -r -t 15 -u 8 ready; then
+        wait "$update_pid" || true
+        check 'managed update reached mock Brew before timeout' false
+    fi
+    check 'update acquired lock before running Brew' test "$ready" = ready
+    if flock -n "${MOCK_PREFIX}/var/dakota-brew-managed.lock" true; then
+        printf 'release\n' >&7
+        wait "$update_pid"
+        check 'managed update must hold shared prefix lock' false
+    fi
+    printf 'release\n' >&7
+    wait "$update_pid"
+    exec 8>&- 7>&-
+    check 'managed lock released after job' flock -n "${MOCK_PREFIX}/var/dakota-brew-managed.lock" true
+fi
+
+reset_fixture
+receipt ublue-os/tap 0.13.0
+check 'newer Bluefin install is not downgraded' run_migration
+check 'newer cask preserved' no_command 'uninstall --cask ublue-os/tap/chairlift'
+
+reset_fixture
+receipt
+mkdir -p "${MOCK_PREFIX}/var/homebrew/pinned_casks"
+ln -s "${MOCK_PREFIX}/Caskroom/chairlift" "${MOCK_PREFIX}/var/homebrew/pinned_casks/chairlift"
+if run_migration true; then check 'pinned cask needs explicit unpin' false; fi
+check 'pinned cask not uninstalled' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+# Regression coverage from the adversarial review: exercise each failure as
+# a negative assertion, then prove that the intended recovery actually works.
+fails_migration() { ! run_migration "${1:-false}"; }
+set_candidate() {
+    printf '%s\n' "$1" > "${FIXTURE}/target-version"
+    printf 'https://github.com/projectbluefin/chairlift/releases/download/v%s/chairlift.tar.gz\n' "$1" > "${FIXTURE}/target-url"
+}
+
+reset_fixture
+receipt
+check 'initial migration for one-time test' run_migration
+set_candidate 0.13.0
+: > "${FIXTURE}/commands"
+: > "${FIXTURE}/info-fail"
+check 'completed migration works offline with a newer candidate' run_migration
+check 'completion does not query mutable candidate' no_command 'info --json=v2 --cask ublue-os/tap/chairlift'
+check 'completion never implements future upgrades' no_command 'uninstall --cask ublue-os/tap/chairlift'
+rm -rf "${MOCK_PREFIX}/Caskroom/chairlift"
+check 'completed migration respects user removal' run_migration
+check 'removed cask not resurrected' no_command 'install --cask --require-sha ublue-os/tap/chairlift'
+receipt
+check 'completion does not authorize a later manual Frostyard install' fails_migration
+check 'later manual Frostyard install preserved' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+reset_fixture
+receipt
+printf '{"casks":["ublue-os/tap/chairlift"]}\n' > "${FIXTURE}/state.json"
+check 'Bluefin managed record cannot authorize Frostyard' fails_migration
+check 'mismatched managed record does not uninstall' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+reset_fixture
+receipt
+: > "${FIXTURE}/fetch-fail"
+check 'failed preparation captures initial ownership' fails_migration
+check 'authorization persists before generic state rewrite' phase authorized
+rm "${FIXTURE}/state.json" "${FIXTURE}/fetch-fail"
+receipt frostyard/tap 0.11.0
+check 'authorization binds original receipt, not just source tap' fails_migration
+check 'changed source version preserved' no_command 'uninstall --cask frostyard/tap/chairlift'
+check 'explicit readoption authorizes changed source' run_migration true
+
+reset_fixture
+receipt
+: > "${FIXTURE}/uninstall-fail"
+check 'create interrupted replacement for fingerprint test' fails_migration
+rm "${FIXTURE}/uninstall-fail"
+printf '\n' >> "${MOCK_PREFIX}/Caskroom/chairlift/.metadata/INSTALL_RECEIPT.json"
+: > "${FIXTURE}/commands"
+check 'pending state rejects even a same-version changed receipt' fails_migration
+check 'changed receipt not removed' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+for change in version sha url; do
+    reset_fixture
+    receipt
+    : > "${FIXTURE}/install-fail"
+    check "create pending install for target ${change} test" fails_migration
+    rm "${FIXTURE}/install-fail"
+    case "$change" in
+        version) set_candidate 0.13.0 ;;
+        sha) printf '%064d\n' 2 > "${FIXTURE}/target-sha" ;;
+        url) printf 'https://github.com/projectbluefin/chairlift/releases/download/v0.12.2/changed.tar.gz\n' > "${FIXTURE}/target-url" ;;
+    esac
+    : > "${FIXTURE}/commands"
+    check "pending target ${change} cannot silently drift" fails_migration
+    check "changed ${change} is not installed" no_command 'install --cask --require-sha ublue-os/tap/chairlift'
+    check "explicit readoption accepts inspected ${change}" run_migration true
+done
+
+reset_fixture
+receipt
+: > "${FIXTURE}/missing-binaries"
+check 'partial target installation fails verification' fails_migration
+rm "${FIXTURE}/missing-binaries" "${FIXTURE}/state.json"
+check 'partial target installation repairs on ordinary retry' run_migration
+check 'partial repair uses native reinstall' has_command 'reinstall --cask --require-sha ublue-os/tap/chairlift'
+check 'partial repair completes' phase complete
+rm "${MOCK_PREFIX}/bin/chairlift-wrapper"
+check 'damage after completion is not silently repaired' fails_migration
+check 'explicit adoption repairs damaged completed installation' run_migration true
+ln -sfn /usr/bin/true "${MOCK_PREFIX}/bin/chairlift"
+check 'unrelated executable cannot satisfy cask health' fails_migration
+
+for operation in fetch uninstall; do
+    reset_fixture
+    receipt
+    : > "${FIXTURE}/change-during-${operation}"
+    check "candidate drift during ${operation} rejected" fails_migration
+    check "candidate drift during ${operation} never installs changed target" no_command 'install --cask --require-sha ublue-os/tap/chairlift'
+    if [[ "$operation" == fetch ]]; then
+        check 'drift detected before removing old cask' no_command 'uninstall --cask frostyard/tap/chairlift'
+    else
+        check 'post-uninstall drift retains recovery checkpoint' phase replacing
+    fi
+done
+
+for version in latest 0.13.0-rc.1 0.10.1; do
+    reset_fixture
+    receipt
+    set_candidate "$version"
+    check "unsupported target ${version} rejected before uninstall" fails_migration
+    check "unsupported ${version} leaves old cask" no_command 'uninstall --cask frostyard/tap/chairlift'
+done
+reset_fixture
+receipt
+printf 'https://github.com/projectbluefin/chairlift/releases/download/v0.13.0/chairlift.tar.gz\n' > "${FIXTURE}/target-url"
+check 'version and URL tag must agree' fails_migration
+check 'mismatched tag leaves old cask' no_command 'uninstall --cask frostyard/tap/chairlift'
+
+for provenance in missing corrupt frostyard; do
+    reset_fixture
+    receipt
+    mkdir -p "${MOCK_PREFIX}/Cellar/orphan/1"
+    case "$provenance" in
+        corrupt) printf 'broken\n' > "${MOCK_PREFIX}/Cellar/orphan/1/INSTALL_RECEIPT.json" ;;
+        frostyard) printf '{"source":{"tap":"frostyard/tap"}}\n' > "${MOCK_PREFIX}/Cellar/orphan/1/INSTALL_RECEIPT.json" ;;
+    esac
+    check "formula with ${provenance} provenance blocks tap removal" fails_migration
+    check "${provenance} formula stops before removing ChairLift" no_command 'uninstall --cask frostyard/tap/chairlift'
+    check "${provenance} formula payload retained" test -d "${MOCK_PREFIX}/Cellar/orphan/1"
+done
+reset_fixture
+printf 'https://github.com/frostyard/chairlift/releases/download/v0.12.2/chairlift.tar.gz\n' > "${FIXTURE}/target-url"
+check 'fresh install rejects stale Frostyard-backed ublue cask' fails_migration
+check 'fresh stale candidate never installed' no_command 'install --cask --require-sha ublue-os/tap/chairlift'
+
+# Execute common's opt-in handoff API directly against a mock prefix. This
+# fixture is test-only; BST consumes common itself, never this copy or a patch.
+common_script=${ROOT}/scripts/fixtures/common-brew-preinstall
+check 'common advertises explicit handoff capability' test "$(bash "$common_script" --capabilities)" = external-chairlift-v1
+if [[ $EUID != 0 ]]; then
+    reset_fixture
+    receipt
+    mkdir -p "${FIXTURE}/preinstall.d" "${MOCK_PREFIX}/var/homebrew/pinned_casks"
+    cp "${ROOT}/files/chairlift/chairlift.Brewfile" "${FIXTURE}/preinstall.d/chairlift.Brewfile"
+    printf 'brew "jq"\n' > "${FIXTURE}/preinstall.d/base.Brewfile"
+    ln -s "${MOCK_PREFIX}/Caskroom/chairlift" "${MOCK_PREFIX}/var/homebrew/pinned_casks/chairlift"
+    sed -e "s|^PREINSTALL_DIR=.*|PREINSTALL_DIR=\"${FIXTURE}/preinstall.d\"|" \
+        -e "s|^STATE_FILE=.*|STATE_FILE=\"${FIXTURE}/state.json\"|" \
+        -e "s|^BREW_BIN=.*|BREW_BIN=\"${MOCK_PREFIX}/bin/brew\"|" \
+        "$common_script" > "${FIXTURE}/preinstall"
+    chmod +x "${FIXTURE}/preinstall"
+    wrapper() {
+        bash -c '
+            source "$1/files/chairlift/dakota-brew-managed"
+            PREFIX=$MOCK_PREFIX BREW_BIN=$MOCK_PREFIX/bin/brew STATE_FILE=$FIXTURE/state.json PREINSTALL=$FIXTURE/preinstall
+            main "$2"
+        ' -- "$ROOT" "$1" > "${FIXTURE}/wrapper-output" 2>&1
+    }
+    if wrapper preinstall; then check 'blocked migration must report failure' false; fi
+    check 'unrelated preinstall proceeds despite pinned ChairLift' has_command "bundle --file=${FIXTURE}/preinstall.d/base.Brewfile"
+    check 'generic lifecycle never bundles ChairLift' no_command "bundle --file=${FIXTURE}/preinstall.d/chairlift.Brewfile"
+    check 'generic lifecycle hands off ChairLift without removal' no_command 'uninstall --cask chairlift'
+    check 'generic state now excludes ChairLift' jq -e '.casks == [] and .packages == ["jq"]' "${FIXTURE}/state.json"
+    check 'authorization survives generic handoff' phase authorized
+    check 'pinned ChairLift cannot block native upgrades' wrapper upgrade
+    check 'native upgrade invoked' has_command upgrade
+    rm "${MOCK_PREFIX}/var/homebrew/pinned_casks/chairlift"
+    check 'migration resumes after generic state drops legacy ownership' wrapper preinstall
+    check 'ownership handoff completes' phase complete
+fi
+
+# Exercise the actual BST install commands with inert upstream assets and a
+# synthetic image root. No modifications to /usr, /etc, or the real prefix.
+stage=${WORK}/stage
+image=${stage}/image
+mkdir -p "${stage}/chairlift-upstream/data/icons/hicolor/"{scalable/apps,symbolic/apps} \
+    "${image}/usr/share/ublue-os/homebrew/preinstall.d" "${image}/usr/bin" \
+    "${image}/usr/share/applications" "${image}/usr/share/polkit-1/actions" "${image}/etc/chairlift" "${image}/usr/share/chairlift"
+cp -r "${ROOT}/files/chairlift" "${stage}/dakota-chairlift"
+mkdir -p "${image}/usr/libexec"
+# Simulate older common safely: it ignores flags and exits 0 with a message.
+# The assembly guard must reject that, not just test the process exit code.
+printf '#!/bin/bash\necho "brew-preinstall: brew not found, skipping"\n' > "${image}/usr/libexec/brew-preinstall"
+printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' \
+    > "${image}/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile"
+printf 'keep my settings\n' > "${image}/etc/chairlift/config.yml"
+printf 'shared schema for old and new casks\n' > "${image}/usr/share/chairlift/config.yml"
+printf 'legacy\n' > "${image}/usr/share/applications/org.frostyard.ChairLift.desktop"
+printf 'legacy\n' > "${image}/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy"
+printf '[Desktop Entry]\nName=ChairLift\nType=Application\nExec=chairlift-wrapper\nIcon=io.projectbluefin.chairlift\n' \
+    > "${stage}/chairlift-upstream/data/io.projectbluefin.chairlift.desktop"
+printf '<policyconfig/>\n' > "${stage}/chairlift-upstream/data/io.projectbluefin.chairlift.bootc.policy"
+for icon in scalable/apps/io.projectbluefin.chairlift.svg scalable/apps/io.projectbluefin.chairlift-flower.svg symbolic/apps/io.projectbluefin.chairlift-symbolic.svg; do
+    printf '<svg/>\n' > "${stage}/chairlift-upstream/data/icons/hicolor/${icon}"
+done
+if (cd "$stage" && bash dakota-chairlift/install.sh "$image") > "${WORK}/old-common-output" 2>&1; then
+    check 'older common must fail image assembly' false
+fi
+check 'old common reports missing capability' grep -Fq 'Common lacks external-chairlift-v1' "${WORK}/old-common-output"
+check 'old common fails before replacing image assets' test "$(< "${image}/usr/share/applications/org.frostyard.ChairLift.desktop")" = legacy
+cp "$common_script" "${image}/usr/libexec/brew-preinstall"
+check 'BST installation script succeeds with upstream handoff API' bash -c 'cd "$1" && bash dakota-chairlift/install.sh "$2"' -- "$stage" "$image"
+check 'Brewfile uses qualified Bluefin cask' cmp "${ROOT}/files/chairlift/chairlift.Brewfile" "${image}/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile"
+check 'old policy removed' test ! -e "${image}/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy"
+check 'old desktop removed' test ! -e "${image}/usr/share/applications/org.frostyard.ChairLift.desktop"
+check 'root-owned policy comes from pinned source' cmp "${stage}/chairlift-upstream/data/io.projectbluefin.chairlift.bootc.policy" "${image}/usr/share/polkit-1/actions/io.projectbluefin.chairlift.bootc.policy"
+check 'no extra privileged policy installed' test "$(find "${image}/usr/share/polkit-1/actions" -type f | wc -l)" -eq 1
+check 'image launcher has absolute brew prefix' grep -Fxq 'Exec=/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper' "${image}/usr/share/applications/io.projectbluefin.chairlift.desktop"
+check 'administrator config preserved during image assembly' test "$(< "${image}/etc/chairlift/config.yml")" = 'keep my settings'
+check 'shared-schema image config preserved' test "$(< "${image}/usr/share/chairlift/config.yml")" = 'shared schema for old and new casks'
+check 'public preinstall wrapper invokes migration' grep -Fq '/usr/libexec/dakota-brew-managed preinstall' "${image}/usr/bin/brew-preinstall"
+for operation in update upgrade; do
+    check "${operation} service shares lock" grep -Fxq "ExecStart=/usr/libexec/dakota-brew-managed ${operation}" "${image}/usr/lib/systemd/system/brew-${operation}.service.d/dakota-managed.conf"
+done
+check 'uupd routes Brew through same lock' grep -Fq '"path": "/usr/libexec/dakota-brew-managed"' "${ROOT}/elements/bluefin/uupd.bst"
+if (cd "$stage" && bash dakota-chairlift/install.sh "$image") > "${WORK}/drift-output" 2>&1; then
+    check 'changed upstream Brewfile must fail assembly' false
+fi
+printf 'tap "frostyard/tap", trusted: true\ncask "frostyard/tap/chairlift"\n' \
+    > "${image}/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile"
+check 'assembly accepts current common qualified legacy declaration' bash -c 'cd "$1" && bash dakota-chairlift/install.sh "$2"' -- "$stage" "$image"
+printf 'All ChairLift migration tests passed.\n'


### PR DESCRIPTION
## Summary

Dakota still preinstalls Frostyard’s ChairLift and leaves its tap enabled, causing conflicts with duplicate cask names. This switches to `ublue-os/tap/chairlift` and adds a one-time migration for existing managed installations.

1. **Switch to Project Bluefin’s ChairLift.** The image uses the qualified Bluefin cask and pinned desktop assets. Existing configuration is preserved, with no additional privileged helpers or changes to bootc authorization requirements.
2. **Migrate existing installs safely.** The migration checks installed receipts, validates and downloads the replacement before uninstalling, and records checkpoints for interrupted-install recovery. It removes `frostyard/tap` only when no remaining packages depend on it. Unknown ownership or other Frostyard packages stop the migration rather than trigger forced removal.
3. **Keep unrelated Brew jobs working.** Migration failures do not block other preinstalled packages or normal upgrades. Managed Brew jobs share a lock, while completed migrations leave future ChairLift upgrades to Homebrew.
4. **Use common’s upstream handoff.** The common pin includes projectbluefin/common#1100, which lets Dakota manage ChairLift separately from generic preinstall. No downstream ChairLift patch is carried.

Verified: All 143 migration assertions, ShellCheck, `just validate`, and targeted builds of `bluefin/common.bst` and `bluefin/uupd.bst` pass. Built-artifact checks confirm the handoff script, Bluefin cask declaration, desktop assets, preserved configuration, and unchanged bootc authorization requirements.

Related: https://github.com/projectbluefin/common/pull/1100