### PR TITLE
feat(hardware): package tuxedo-drivers kernel modules and quirks

### DIFF
--- a/.agents/skills/dakota-buildstream/SKILL.md
+++ b/.agents/skills/dakota-buildstream/SKILL.md
@@ -46,6 +46,7 @@ Never translate RPM, DNF, COPR, or Containerfile workflows into this repository.
   ```bash
   python3 files/scripts/generate_cargo_sources.py path/to/Cargo.lock
   ```
+- **Out-of-Tree Kernel Modules**: Build against `/usr/lib/modules/$KVER/build` provided by `freedesktop-sdk.bst:components/linux.bst`. Defer `depmod` from the driver element's `install-commands` to the composed layer stack's `integration-commands` (`depmod -a "$KVER"`).
 
 ## Common Rationalizations
 

--- a/elements/bluefin/tuxedo-drivers.bst
+++ b/elements/bluefin/tuxedo-drivers.bst
@@ -1,0 +1,50 @@
+kind: manual
+description: |
+  Out-of-tree kernel modules and udev hardware quirks for TUXEDO laptops.
+  Provides platform drivers, keyboard backlight, fan and power sensors,
+  and /dev/tuxedo_io for Clevo and Uniwill/Tongfang ODM chassis.
+
+build-depends:
+- freedesktop-sdk.bst:bootstrap/coreutils.bst
+- freedesktop-sdk.bst:bootstrap/bash.bst
+- freedesktop-sdk.bst:components/gcc-base.bst
+- freedesktop-sdk.bst:bootstrap/binutils.bst
+- freedesktop-sdk.bst:components/make.bst
+- freedesktop-sdk.bst:components/linux.bst
+# Kernel's objtool is dynamically linked against libxxhash.so.0
+- freedesktop-sdk.bst:components/xxhash.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+sources:
+- kind: git_repo
+  url: gitlab:tuxedocomputers/development/packages/tuxedo-drivers.git
+  track: main
+  ref: 2c6bf54075fb38a7fdbefc560734281984bf65bc
+
+config:
+  build-commands:
+  - |
+    set -euo pipefail
+    KVER=$(ls /usr/lib/modules | head -n1)
+    if [ -z "$KVER" ] || [ ! -d "/usr/lib/modules/$KVER/build" ]; then
+        echo "FATAL: no kernel build tree found under /usr/lib/modules" >&2
+        exit 1
+    fi
+    echo "Building TUXEDO kernel modules against $KVER"
+    make -j${BST_BUILD_THREADS:-1} -C "/usr/lib/modules/$KVER/build" M="$PWD" modules
+
+  install-commands:
+  # depmod is intentionally deferred to OCI layer composition time
+  - |
+    set -euo pipefail
+    KVER=$(ls /usr/lib/modules | head -n1)
+    make -j1 -C "/usr/lib/modules/$KVER/build" M="$PWD" modules_install \
+        INSTALL_MOD_PATH="%{install-root}%{prefix}"
+  - |
+    set -euo pipefail
+    # Install hardware quirks, udev rules, and modprobe configuration
+    if [ -d files/usr ]; then
+        cp -r files/usr/* "%{install-root}%{prefix}/"
+    fi

--- a/elements/oci/layers/bluefin-stack.bst
+++ b/elements/oci/layers/bluefin-stack.bst
@@ -8,6 +8,7 @@ depends:
   - core/ntsync-modules-load.bst
   - gnome-build-meta.bst:gnomeos/initramfs/signed-modules.bst
   - gnome-build-meta.bst:oci/initramfs.bst
+  - bluefin/tuxedo-drivers.bst
 
   - gnome-build-meta.bst:gnomeos-deps/bootc.bst
   - gnome-build-meta.bst:oci/integration/bootc-config.bst
@@ -31,6 +32,13 @@ public:
       # so this is the deterministic winner. No [zramN] section = no zram device.
       - printf '# zram disabled; Dakota swaps via zswap + /var/swap/swapfile\n' > /usr/lib/systemd/zram-generator.conf
 
+      # Re-run depmod against the composed root so modprobe sees
+      # out-of-tree modules (e.g. tuxedo-drivers) alongside in-tree modules.
+      - |
+        KVER=$(ls /usr/lib/modules | head -n1)
+        if [ -n "$KVER" ]; then
+            depmod -a "$KVER"
+        fi
       - rm -rfv /boot /run
 
       # Required for bootc to create the image


### PR DESCRIPTION
OK so this is 600k ondisk and they only load if you need it. I want to see how doable this is, I suspect easy with hive. Tuxedo is the only one in Europe we've had contact with, they sponsored the linuxapp summit, and we had lots of great convos. 

They want to get to the right place with upstream kernels but it's a long complicated thing and the new people are stuck fixing it. So let's give them all a kickass OS. 😄 

I'm thinking roll with this for a while but not make a habit of it. I think knowing that they intend to get better is a good indicator.

### Summary
- Packages `tuxedo-drivers` as an out-of-tree kernel module element built against Dakota's pinned kernel headers (`freedesktop-sdk.bst:components/linux.bst`).
- Stages all 27 kernel modules (`tuxedo_keyboard`, `tuxedo_io`, `clevo_acpi`, `clevo_wmi`, `uniwill_wmi`, `ite_829x`, `tuxedo_nb04_*`, `tuxedo_nb05_*`, etc.).
- Installs upstream hardware quirks and udev rules (hwdb remappings for Fn keys and accelerometer orientation matrix, modprobe conflicts blacklist).
- Includes the element in `elements/oci/layers/bluefin-stack.bst` with layer integration command `depmod -a $KVER`.
- Updates `.agents/skills/dakota-buildstream/SKILL.md` per the factory two-output rule.

Assisted-by: Pi