### PR TITLE
fix(ci): isolate ChairLift tests from runner defaults

### DIFF
--- a/scripts/fixtures/chairlift-brew
+++ b/scripts/fixtures/chairlift-brew
@@ -2,6 +2,12 @@
 # Offline test double. Never delegates to the host's real Homebrew.
 set -euo pipefail
 : "${FIXTURE:?}" "${MOCK_PREFIX:?}"
+# Default native jobs use the suite's clean baseline. Preservation tests opt
+# into caller-provided settings; migration overrides must never leak here.
+check_native_environment() {
+    [[ ${HOMEBREW_NO_AUTO_UPDATE:-} == "${MOCK_EXPECTED_NO_AUTO_UPDATE:-}" ]] || exit 92
+    [[ $(umask) == "${MOCK_EXPECTED_UMASK:-0022}" ]] || exit 93
+}
 printf '%s\n' "$*" >> "${FIXTURE}/commands"
 if [[ ${HOMEBREW_DEVELOPER:-} == 1 ]]; then printf '%s\n' "$*" >> "${FIXTURE}/developer-commands"; fi
 case "$*" in
@@ -56,16 +62,14 @@ case "$*" in
         printf 'export PATH="%s/bin:$PATH"\n' "$MOCK_PREFIX" ;;
     bundle*)
         [[ "$*" != *chairlift.Brewfile* ]] || exit 91
-        [[ ${HOMEBREW_NO_AUTO_UPDATE:-} != 1 ]] || exit 92 ;;
+        check_native_environment ;;
     update)
-        [[ ${HOMEBREW_NO_AUTO_UPDATE:-} != 1 ]] || exit 92
-        [[ $(umask) != 0077 ]] || exit 93
+        check_native_environment
         if [[ -p ${FIXTURE}/update-ready ]]; then
             printf 'ready\n' > "${FIXTURE}/update-ready"
             read -r _ < "${FIXTURE}/update-release"
         fi ;;
     upgrade)
-        [[ ${HOMEBREW_NO_AUTO_UPDATE:-} != 1 ]] || exit 92
-        [[ $(umask) != 0077 ]] || exit 93 ;;
+        check_native_environment ;;
     *) printf 'Unexpected mock brew invocation: %s\n' "$*" >&2; exit 99 ;;
 esac

--- a/scripts/test_chairlift_migration.sh
+++ b/scripts/test_chairlift_migration.sh
@@ -3,6 +3,12 @@
 # Single-quoted programs deliberately expand in the isolated child shell.
 # shellcheck disable=SC2016
 set -euo pipefail
+# Assert migration isolation against a known baseline, not the caller's Brew
+# settings (GitHub's Ubuntu runners export HOMEBREW_NO_AUTO_UPDATE=1).
+# These changes affect only this test process and its temporary fixtures.
+unset HOMEBREW_NO_AUTO_UPDATE HOMEBREW_NO_INSTALL_CLEANUP HOMEBREW_NO_AUTOREMOVE \
+    HOMEBREW_NO_ANALYTICS HOMEBREW_NO_ASK HOMEBREW_DEVELOPER
+umask 022
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -11,6 +17,7 @@ reset_fixture() {
     FIXTURE=$(mktemp -d "${WORK}/case.XXXXXX")
     MOCK_PREFIX=${FIXTURE}/prefix
     export FIXTURE MOCK_PREFIX
+    export MOCK_EXPECTED_NO_AUTO_UPDATE='' MOCK_EXPECTED_UMASK=0022
     mkdir -p "${MOCK_PREFIX}/bin" "${MOCK_PREFIX}/var" "${MOCK_PREFIX}/Caskroom" "${MOCK_PREFIX}/Cellar"
     cp "${ROOT}/scripts/fixtures/chairlift-brew" "${MOCK_PREFIX}/bin/brew"
     chmod +x "${MOCK_PREFIX}/bin/brew"
@@ -229,6 +236,20 @@ if [[ $EUID != 0 ]]; then
     wait "$update_pid"
     exec 8>&- 7>&-
     check 'managed lock released after job' flock -n "${MOCK_PREFIX}/var/dakota-brew-managed.lock" true
+
+    # Native jobs must also preserve intentional caller settings; fixing the
+    # test baseline must not encourage stripping them in the real wrapper.
+    for operation in update upgrade; do
+        reset_fixture
+        check "${operation} preserves caller Homebrew settings and umask" bash -c '
+            source "$1/files/chairlift/dakota-brew-managed"
+            PREFIX=$MOCK_PREFIX BREW_BIN=$MOCK_PREFIX/bin/brew
+            export HOMEBREW_NO_AUTO_UPDATE=1 MOCK_EXPECTED_NO_AUTO_UPDATE=1 MOCK_EXPECTED_UMASK=0077
+            umask 0077
+            main "$2"
+        ' -- "$ROOT" "$operation"
+        check "${operation} invokes only native Brew" test "$(< "${FIXTURE}/commands")" = "$operation"
+    done
 fi
 
 reset_fixture


### PR DESCRIPTION
## Summary

New PRs fail Validate at `upgrade is independent of migration` because GitHub’s Ubuntu runners export `HOMEBREW_NO_AUTO_UPDATE=1`. The ChairLift tests introduced in #1542 mistake that inherited setting for an environment leak from migration.

1. **Establish a controlled test environment.** Reset Homebrew overrides and the umask inside the test process so runner defaults cannot affect migration-isolation assertions.
2. **Preserve caller-setting coverage.** Verify that ordinary updates and upgrades retain explicitly supplied Homebrew settings and permissions.
3. **Keep leakage checks intact.** Make the mock compare against explicit expectations rather than rejecting settings that a caller may intentionally supply.

Production code and workflow configuration are unchanged.

Verified: The migration suite passes with a clean environment. `just check-publish-workflow` passes with `HOMEBREW_NO_AUTO_UPDATE=1` and umask `0077`. ShellCheck, Bash syntax checks, and mock leakage guards pass. Full BuildStream validation and image or hardware testing were not run.

Related: #1542, #1545, #1546, #1547, #1549
