### PR TITLE
chore(next): advance GNOME 51 with synced patches

### DIFF
--- a/elements/gnome-build-meta.bst
+++ b/elements/gnome-build-meta.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: gnome:gnome-build-meta.git
   track: gnome-51
-  ref: 51.beta-29-g884873afcd673867ce1fa72f53d83a16aa2c40bf
+  ref: 51.rc-2-ge79d494f3c5f69f046517ae9674e2904e0ebfdf6
 
 config:
   options:

--- a/patches/freedesktop-sdk.manifest.json
+++ b/patches/freedesktop-sdk.manifest.json
@@ -3,5 +3,5 @@
   "files": {
     "0001-project.conf-Add-GNOME-CAS-servers.patch": "2a79bad1e6159c0b31a9cd5b914a7eb34f0431c406b27974fe12dbe5990d49e7"
   },
-  "gnome-build-meta-sha": "884873afcd673867ce1fa72f53d83a16aa2c40bf"
+  "gnome-build-meta-sha": "e79d494f3c5f69f046517ae9674e2904e0ebfdf6"
 }


### PR DESCRIPTION
## Summary

This updates the next stream to GNOME Build Meta `51.rc-2` and keeps its freedesktop-sdk patch manifest aligned with the new pin.

1. **Update GNOME Build Meta.** Track `gnome-51` to commit `e79d494f3c5f69f046517ae9674e2904e0ebfdf6`.
2. **Sync the patch manifest.** Regenerate the manifest against the tracked commit. The patch contents and freedesktop-sdk pin are unchanged.

Verified: `just patch-drift-check`, BuildStream graph checks for the default and NVIDIA images, and `git diff --check` passed.

Related: #1555
